### PR TITLE
Convert bUnit test interactions to async

### DIFF
--- a/JournalApp.Tests/CalendarTests.razor
+++ b/JournalApp.Tests/CalendarTests.razor
@@ -18,33 +18,33 @@
     }
 
     [Fact]
-    public void SwitchYear()
+    public async Task SwitchYear()
     {
         var cut = Render<CalendarPage>(p =>
         p.Add(x => x.OpenToDateString, "20000101")
     );
 
-        cut.WaitForAssertion(() => cut.Find(".calendar-view"));
+        await cut.WaitForAssertionAsync(() => cut.Find(".calendar-view"));
 
         // Back.
         var year = cut.Instance.SelectedYear;
-        cut.Find(".switcher .previous-button").Click();
+        await cut.Find(".switcher .previous-button").ClickAsync();
         cut.Instance.SelectedYear.Should().Be(year - 1);
 
         // Next.
         year = cut.Instance.SelectedYear;
-        cut.Find(".switcher .next-button").Click();
+        await cut.Find(".switcher .next-button").ClickAsync();
         cut.Instance.SelectedYear.Should().Be(year + 1);
 
         // Current.
         cut.Instance.SelectedYear.Should().NotBe(DateTime.Now.Year);
-        cut.Find(".year-button").Click();
+        await cut.Find(".year-button").ClickAsync();
         cut.Instance.SelectedYear.Should().Be(DateTime.Now.Year);
 
         // Can't go further.
         year = cut.Instance.SelectedYear;
         cut.Find(".switcher .next-button").HasAttribute("disabled").Should().BeTrue();
-        cut.Find(".switcher .next-button").Click();
+        await cut.Find(".switcher .next-button").ClickAsync();
         cut.Instance.SelectedYear.Should().Be(year);
     }
 
@@ -57,7 +57,7 @@
         cut.Instance.SelectedYear.Should().Be(2023);
 
         // Wait for calendar to load.
-        cut.WaitForAssertion(() => cut.Find(".calendar-view"));
+        await cut.WaitForAssertionAsync(() => cut.Find(".calendar-view"));
         cut.FindAll(".calendar-month").Count.Should().Be(12);
 
         var calendarService = Services.GetService<CalendarService>();
@@ -67,7 +67,7 @@
         // 2023, fully filled out leap year.
         cut.FindAll(".calendar-view .calendar-day-cell > .calendar-day-with-mood").Count.Should().Be(filledDays);
 
-        cut.Find(".switcher .previous-button").Click();
+        await cut.Find(".switcher .previous-button").ClickAsync();
         cut.Instance.SelectedYear.Should().Be(2022);
 
         // 2022, none filled.
@@ -75,7 +75,7 @@
     }
 
     [Fact]
-    public void CalendarViewRespectsFirstDay()
+    public async Task CalendarViewRespectsFirstDay()
     {
         var _culture = (CultureInfo)CultureInfo.CurrentCulture.Clone();
         _culture.DateTimeFormat.FirstDayOfWeek = DayOfWeek.Wednesday;
@@ -87,7 +87,7 @@
         cut.Instance.SelectedYear.Should().Be(2023);
 
         // Wait for calendar to load.
-        cut.WaitForAssertion(() => cut.Find(".calendar-view"));
+        await cut.WaitForAssertionAsync(() => cut.Find(".calendar-view"));
 
         var weekHeaders = cut.FindAll(".calendar-week-row > .calendar-day-cell");
         weekHeaders[0].TextContent.Should().Be("We");

--- a/JournalApp.Tests/DataPointViewTests.razor
+++ b/JournalApp.Tests/DataPointViewTests.razor
@@ -3,7 +3,7 @@
 
 @code {
     [Fact]
-    public void Mood()
+    public async Task Mood()
     {
         var category = new DataPointCategory
         {
@@ -25,20 +25,20 @@
         var cut = layout.FindComponent<DataPointView>();
 
         // Click the emoji button to open the popover
-        cut.Find(".emoji-button").Click();
+        await cut.Find(".emoji-button").ClickAsync();
 
-        layout.WaitForAssertion(() => layout.FindAll("div.mud-popover-open").Count.Should().Be(1));
+        await layout.WaitForAssertionAsync(() => layout.FindAll("div.mud-popover-open").Count.Should().Be(1));
         
         // Click the first emoji button in the popover
-        layout.WaitForAssertion(() => layout.FindAll(".emoji-popover-content .emoji-button").Count.Should().BeGreaterThan(0));
+        await layout.WaitForAssertionAsync(() => layout.FindAll(".emoji-popover-content .emoji-button").Count.Should().BeGreaterThan(0));
         var emojiButtons = layout.FindAll(".emoji-popover-content .emoji-button");
-        emojiButtons[0].Click();
+        await emojiButtons[0].ClickAsync();
         
         point.Mood.Should().Be("🤔");
     }
 
     [Fact]
-    public void Mood_SobEmoji_ShowsMotivationalQuote()
+    public async Task Mood_SobEmoji_ShowsMotivationalQuote()
     {
         var category = new DataPointCategory
         {
@@ -59,15 +59,15 @@
         var cut = layout.FindComponent<DataPointView>();
 
         // Open the mood popover
-        cut.Find(".emoji-button").Click();
+        await cut.Find(".emoji-button").ClickAsync();
 
         // Find and click the sob emoji (😭 is the last item in DataPoint.Moods)
         var sobEmoji = DataPoint.Moods[^1];  // Get the last mood (sob emoji)
         sobEmoji.Should().Be("😭");  // Verify it's the sob emoji
         
-        layout.WaitForAssertion(() => layout.FindAll(".emoji-popover-content .emoji-button").Count.Should().Be(DataPoint.Moods.Count));
+        await layout.WaitForAssertionAsync(() => layout.FindAll(".emoji-popover-content .emoji-button").Count.Should().Be(DataPoint.Moods.Count));
         var emojiButtons = layout.FindAll(".emoji-popover-content .emoji-button");
-        emojiButtons[^1].Click();  // Click the last emoji button (sob emoji)
+        await emojiButtons[^1].ClickAsync();  // Click the last emoji button (sob emoji)
 
         // Verify mood was set
         point.Mood.Should().Be(sobEmoji);
@@ -77,7 +77,7 @@
     }
 
     [Fact]
-    public void Sleep()
+    public async Task Sleep()
     {
         var category = new DataPointCategory
         {
@@ -96,7 +96,7 @@
         cut.Find(".sleep-hours").TextContent.Should().Be("08.5");
 
         for (var i = 0; i < 50; i++)
-            cut.Find(".less-sleep").Click();
+            await cut.Find(".less-sleep").ClickAsync();
 
         point.SleepHours.Should().Be(0);
         cut.Find(".sleep-hours").TextContent.Should().Be("00.0");
@@ -104,7 +104,7 @@
         cut.Find(".more-sleep").HasAttribute("disabled").Should().BeFalse();
 
         for (var i = 0; i < 50; i++)
-            cut.Find(".more-sleep").Click();
+            await cut.Find(".more-sleep").ClickAsync();
 
         point.SleepHours.Should().Be(24);
         cut.Find(".sleep-hours").TextContent.Should().Be("24.0");
@@ -113,7 +113,7 @@
     }
 
     [Fact]
-    public void Scale()
+    public async Task Scale()
     {
         var category = new DataPointCategory
         {
@@ -131,17 +131,17 @@
         point.ScaleIndex.Should().Be(null);
         cut.FindAll(".mud-rating-item").Count.Should().Be(5);
 
-        cut.FindAll(".mud-rating-item")[2].Click();
+        await cut.FindAll(".mud-rating-item")[2].ClickAsync();
         point.ScaleIndex.Should().Be(3);
 
-        cut.FindAll(".mud-rating-item")[2].Click();
+        await cut.FindAll(".mud-rating-item")[2].ClickAsync();
         point.ScaleIndex.Should().Be(null);
     }
 
     [Theory]
     [InlineData(PointType.LowToHigh)]
     [InlineData(PointType.MildToSevere)]
-    public void ScaleEnums(PointType type)
+    public async Task ScaleEnums(PointType type)
     {
         var category = new DataPointCategory
         {
@@ -160,25 +160,25 @@
         cut.FindAll(".mud-toggle-item").Count.Should().Be(4);
         cut.FindAll(".mud-toggle-item-selected").Count.Should().Be(0);
 
-        cut.FindAll(".mud-toggle-item")[1].Click();
+        await cut.FindAll(".mud-toggle-item")[1].ClickAsync();
         cut.FindAll(".mud-toggle-item")[1].ClassList.Should().Contain("mud-toggle-item-selected");
         point.ScaleIndex.Should().Be(1);
 
-        cut.FindAll(".mud-toggle-item")[2].Click();
+        await cut.FindAll(".mud-toggle-item")[2].ClickAsync();
         cut.FindAll(".mud-toggle-item")[2].ClassList.Should().Contain("mud-toggle-item-selected");
         point.ScaleIndex.Should().Be(3);
 
-        cut.FindAll(".mud-toggle-item")[3].Click();
+        await cut.FindAll(".mud-toggle-item")[3].ClickAsync();
         cut.FindAll(".mud-toggle-item")[3].ClassList.Should().Contain("mud-toggle-item-selected");
         point.ScaleIndex.Should().Be(5);
 
-        cut.FindAll(".mud-toggle-item")[3].Click();
+        await cut.FindAll(".mud-toggle-item")[3].ClickAsync();
         cut.FindAll(".mud-toggle-item")[3].ClassList.Should().NotContain("mud-toggle-item-selected");
         point.ScaleIndex.Should().Be(null);
     }
 
     [Fact]
-    public void Number()
+    public async Task Number()
     {
         var category = new DataPointCategory
         {
@@ -194,12 +194,12 @@
         );
 
         point.Number.Should().Be(null);
-        cut.Find("input").Input("321");
+        await cut.Find("input").InputAsync("321");
         point.Number.Should().Be(321);
     }
 
     [Fact]
-    public void Text()
+    public async Task Text()
     {
         var category = new DataPointCategory
         {
@@ -215,12 +215,12 @@
         );
 
         point.Text.Should().Be(null);
-        cut.Find("input").Input("321");
+        await cut.Find("input").InputAsync("321");
         point.Text.Should().Be("321");
     }
 
     [Fact]
-    public void Note()
+    public async Task Note()
     {
         var category = new DataPointCategory
         {
@@ -243,25 +243,25 @@
 
         cut.Find("button[aria-label='Edit note']").Click();
 
-        layout.WaitForAssertion(() => layout.HasComponent<EditNoteDialog>().Should().BeTrue());
+        await layout.WaitForAssertionAsync(() => layout.HasComponent<EditNoteDialog>().Should().BeTrue());
         var noteEditor = layout.FindComponent<EditNoteDialog>();
-        noteEditor.Find("textarea").Input("123");
-        layout.Find(".submit-button").Click();
+        await noteEditor.Find("textarea").InputAsync("123");
+        await layout.Find(".submit-button").ClickAsync();
 
         point.Text.Should().Be("123");
 
         cut.Find("button[aria-label='Edit note']").Click();
 
-        layout.WaitForAssertion(() => layout.HasComponent<EditNoteDialog>().Should().BeTrue());
+        await layout.WaitForAssertionAsync(() => layout.HasComponent<EditNoteDialog>().Should().BeTrue());
         noteEditor = layout.FindComponent<EditNoteDialog>();
-        noteEditor.Find("textarea").Input("EXTRA TEXT THAT WILL BE DISCARDED");
-        layout.Find(".cancel-button").Click();
+        await noteEditor.Find("textarea").InputAsync("EXTRA TEXT THAT WILL BE DISCARDED");
+        await layout.Find(".cancel-button").ClickAsync();
 
         point.Text.Should().Be("123");
     }
 
     [Fact]
-    public void Medication()
+    public async Task Medication()
     {
         var category = new DataPointCategory
         {
@@ -291,20 +291,20 @@
         // A changed dose should get reset to default when clicking No.
         point.MedicationDose--;
 
-        cut.FindAll(".mud-toggle-item")[0].Click();
+        await cut.FindAll(".mud-toggle-item")[0].ClickAsync();
         cut.FindAll(".mud-toggle-item")[0].ClassList.Should().Contain("mud-toggle-item-selected");
         point.Bool.Should().Be(false);
 
         point.MedicationDose.Should().Be(point.Category.MedicationDose);
 
-        cut.FindAll(".mud-toggle-item")[1].Click();
+        await cut.FindAll(".mud-toggle-item")[1].ClickAsync();
         cut.FindAll(".mud-toggle-item")[1].ClassList.Should().Contain("mud-toggle-item-selected");
         point.Bool.Should().Be(true);
 
         // A changed dose should get reset to default when unselecting.
         point.MedicationDose--;
 
-        cut.FindAll(".mud-toggle-item")[1].Click();
+        await cut.FindAll(".mud-toggle-item")[1].ClickAsync();
         cut.FindAll(".mud-toggle-item")[1].ClassList.Should().NotContain("mud-toggle-item-selected");
         point.Bool.Should().Be(null);
 
@@ -312,7 +312,7 @@
     }
 
     [Fact]
-    public void MedicationEditDose()
+    public async Task MedicationEditDose()
     {
         var category = new DataPointCategory
         {
@@ -342,10 +342,10 @@
 
         // Change dose to empty via dialog.
         cut.Find(".mud-link").Click();
-        layout.WaitForAssertion(() => layout.HasComponent<EditDoseDialog>().Should().BeTrue());
+        await layout.WaitForAssertionAsync(() => layout.HasComponent<EditDoseDialog>().Should().BeTrue());
         var doseEditor = layout.FindComponent<EditDoseDialog>();
-        doseEditor.Find("input").Input("");
-        layout.Find(".submit-button").Click();
+        await doseEditor.Find("input").InputAsync("");
+        await layout.Find(".submit-button").ClickAsync();
 
         // Empty dose resets to default and selects No.
         point.MedicationDose.Should().Be(point.Category.MedicationDose);
@@ -353,10 +353,10 @@
 
         // Change dose via dialog.
         cut.Find(".mud-link").Click();
-        layout.WaitForAssertion(() => layout.HasComponent<EditDoseDialog>().Should().BeTrue());
+        await layout.WaitForAssertionAsync(() => layout.HasComponent<EditDoseDialog>().Should().BeTrue());
         doseEditor = layout.FindComponent<EditDoseDialog>();
-        doseEditor.Find("input").Input("99");
-        layout.Find(".submit-button").Click();
+        await doseEditor.Find("input").InputAsync("99");
+        await layout.Find(".submit-button").ClickAsync();
 
         // Submitting dose is the same as Yes.
         point.MedicationDose.Should().Be(99);
@@ -364,10 +364,10 @@
 
         // Cancel dialog.
         cut.Find(".mud-link").Click();
-        layout.WaitForAssertion(() => layout.HasComponent<EditDoseDialog>().Should().BeTrue());
+        await layout.WaitForAssertionAsync(() => layout.HasComponent<EditDoseDialog>().Should().BeTrue());
         doseEditor = layout.FindComponent<EditDoseDialog>();
-        doseEditor.Find("input").Input("88");
-        layout.Find(".cancel-button").Click();
+        await doseEditor.Find("input").InputAsync("88");
+        await layout.Find(".cancel-button").ClickAsync();
 
         // Same as before
         point.MedicationDose.Should().Be(99);
@@ -400,7 +400,7 @@
     }
 
     [Fact]
-    public void MedicationEditDoseDialogCloses()
+    public async Task MedicationEditDoseDialogCloses()
     {
         var category = new DataPointCategory
         {
@@ -428,19 +428,19 @@
 
         // Submit.
         cut.Find(".mud-link").Click();
-        layout.WaitForAssertion(() => layout.FindAll(".mud-dialog").Count.Should().Be(1));
-        layout.Find(".submit-button").Click();
-        layout.WaitForAssertion(() => layout.FindAll(".mud-dialog").Count.Should().Be(0));
+        await layout.WaitForAssertionAsync(() => layout.FindAll(".mud-dialog").Count.Should().Be(1));
+        await layout.Find(".submit-button").ClickAsync();
+        await layout.WaitForAssertionAsync(() => layout.FindAll(".mud-dialog").Count.Should().Be(0));
 
         // Cancel.
         cut.Find(".mud-link").Click();
-        layout.WaitForAssertion(() => layout.FindAll(".mud-dialog").Count.Should().Be(1));
-        layout.Find(".cancel-button").Click();
-        layout.WaitForAssertion(() => layout.FindAll(".mud-dialog").Count.Should().Be(0));
+        await layout.WaitForAssertionAsync(() => layout.FindAll(".mud-dialog").Count.Should().Be(1));
+        await layout.Find(".cancel-button").ClickAsync();
+        await layout.WaitForAssertionAsync(() => layout.FindAll(".mud-dialog").Count.Should().Be(0));
     }
 
     [Fact]
-    public void Medication_InvokesStateChanged_WhenTakenChanges()
+    public async Task Medication_InvokesStateChanged_WhenTakenChanges()
     {
         var category = new DataPointCategory
         {
@@ -457,14 +457,14 @@
             .Add(x => x.Point, point)
             .Add(x => x.StateChanged, () => stateChangedCalls++));
 
-        cut.FindAll(".mud-toggle-item")[0].Click();
+        await cut.FindAll(".mud-toggle-item")[0].ClickAsync();
 
         point.Bool.Should().Be(false);
         stateChangedCalls.Should().Be(1);
     }
 
     [Fact]
-    public void Note_EditInvokesStateChanged_WhenDialogSubmits()
+    public async Task Note_EditInvokesStateChanged_WhenDialogSubmits()
     {
         var category = new DataPointCategory
         {
@@ -488,9 +488,9 @@
         var cut = layout.FindComponent<DataPointView>();
 
         cut.Find("button[aria-label='Edit note']").Click();
-        layout.WaitForAssertion(() => layout.HasComponent<EditNoteDialog>().Should().BeTrue());
-        layout.FindComponent<EditNoteDialog>().Find("textarea").Input("Updated");
-        layout.Find(".submit-button").Click();
+        await layout.WaitForAssertionAsync(() => layout.HasComponent<EditNoteDialog>().Should().BeTrue());
+        await layout.FindComponent<EditNoteDialog>().Find("textarea").InputAsync("Updated");
+        await layout.Find(".submit-button").ClickAsync();
 
         point.Text.Should().Be("Updated");
         stateChangedCalls.Should().Be(1);

--- a/JournalApp.Tests/DataPointViewTests.razor
+++ b/JournalApp.Tests/DataPointViewTests.razor
@@ -241,6 +241,7 @@
 
         var cut = layout.FindComponent<DataPointView>();
 
+        // Keep sync: the click handler awaits the dialog result; ClickAsync would block until the dialog closes.
         cut.Find("button[aria-label='Edit note']").Click();
 
         await layout.WaitForAssertionAsync(() => layout.HasComponent<EditNoteDialog>().Should().BeTrue());
@@ -250,6 +251,7 @@
 
         point.Text.Should().Be("123");
 
+        // Keep sync: the click handler awaits the dialog result; ClickAsync would block until the dialog closes.
         cut.Find("button[aria-label='Edit note']").Click();
 
         await layout.WaitForAssertionAsync(() => layout.HasComponent<EditNoteDialog>().Should().BeTrue());
@@ -341,6 +343,7 @@
         cut.FindAll(".mud-toggle-item-selected").Count.Should().Be(0);
 
         // Change dose to empty via dialog.
+        // Keep sync: the click handler awaits the dialog result; ClickAsync would block until the dialog closes.
         cut.Find(".mud-link").Click();
         await layout.WaitForAssertionAsync(() => layout.HasComponent<EditDoseDialog>().Should().BeTrue());
         var doseEditor = layout.FindComponent<EditDoseDialog>();
@@ -352,6 +355,7 @@
         cut.FindAll(".mud-toggle-item")[0].ClassList.Should().Contain("mud-toggle-item-selected");
 
         // Change dose via dialog.
+        // Keep sync: the click handler awaits the dialog result; ClickAsync would block until the dialog closes.
         cut.Find(".mud-link").Click();
         await layout.WaitForAssertionAsync(() => layout.HasComponent<EditDoseDialog>().Should().BeTrue());
         doseEditor = layout.FindComponent<EditDoseDialog>();
@@ -363,6 +367,7 @@
         cut.FindAll(".mud-toggle-item")[1].ClassList.Should().Contain("mud-toggle-item-selected");
 
         // Cancel dialog.
+        // Keep sync: the click handler awaits the dialog result; ClickAsync would block until the dialog closes.
         cut.Find(".mud-link").Click();
         await layout.WaitForAssertionAsync(() => layout.HasComponent<EditDoseDialog>().Should().BeTrue());
         doseEditor = layout.FindComponent<EditDoseDialog>();
@@ -427,12 +432,14 @@
         layout.FindAll(".mud-dialog").Count.Should().Be(0);
 
         // Submit.
+        // Keep sync: the click handler awaits the dialog result; ClickAsync would block until the dialog closes.
         cut.Find(".mud-link").Click();
         await layout.WaitForAssertionAsync(() => layout.FindAll(".mud-dialog").Count.Should().Be(1));
         await layout.Find(".submit-button").ClickAsync();
         await layout.WaitForAssertionAsync(() => layout.FindAll(".mud-dialog").Count.Should().Be(0));
 
         // Cancel.
+        // Keep sync: the click handler awaits the dialog result; ClickAsync would block until the dialog closes.
         cut.Find(".mud-link").Click();
         await layout.WaitForAssertionAsync(() => layout.FindAll(".mud-dialog").Count.Should().Be(1));
         await layout.Find(".cancel-button").ClickAsync();
@@ -487,6 +494,7 @@
 
         var cut = layout.FindComponent<DataPointView>();
 
+        // Keep sync: the click handler awaits the dialog result; ClickAsync would block until the dialog closes.
         cut.Find("button[aria-label='Edit note']").Click();
         await layout.WaitForAssertionAsync(() => layout.HasComponent<EditNoteDialog>().Should().BeTrue());
         await layout.FindComponent<EditNoteDialog>().Find("textarea").InputAsync("Updated");

--- a/JournalApp.Tests/DataPointViewTests.razor
+++ b/JournalApp.Tests/DataPointViewTests.razor
@@ -241,8 +241,7 @@
 
         var cut = layout.FindComponent<DataPointView>();
 
-        // Keep sync: the click handler awaits the dialog result; ClickAsync would block until the dialog closes.
-        cut.Find("button[aria-label='Edit note']").Click();
+        cut.Find("button[aria-label='Edit note']").Click(); // Keep sync: the click handler awaits the dialog result; ClickAsync would block until the dialog closes.
 
         await layout.WaitForAssertionAsync(() => layout.HasComponent<EditNoteDialog>().Should().BeTrue());
         var noteEditor = layout.FindComponent<EditNoteDialog>();
@@ -251,8 +250,7 @@
 
         point.Text.Should().Be("123");
 
-        // Keep sync: the click handler awaits the dialog result; ClickAsync would block until the dialog closes.
-        cut.Find("button[aria-label='Edit note']").Click();
+        cut.Find("button[aria-label='Edit note']").Click(); // Keep sync: the click handler awaits the dialog result; ClickAsync would block until the dialog closes.
 
         await layout.WaitForAssertionAsync(() => layout.HasComponent<EditNoteDialog>().Should().BeTrue());
         noteEditor = layout.FindComponent<EditNoteDialog>();
@@ -343,8 +341,7 @@
         cut.FindAll(".mud-toggle-item-selected").Count.Should().Be(0);
 
         // Change dose to empty via dialog.
-        // Keep sync: the click handler awaits the dialog result; ClickAsync would block until the dialog closes.
-        cut.Find(".mud-link").Click();
+        cut.Find(".mud-link").Click(); // Keep sync: the click handler awaits the dialog result; ClickAsync would block until the dialog closes.
         await layout.WaitForAssertionAsync(() => layout.HasComponent<EditDoseDialog>().Should().BeTrue());
         var doseEditor = layout.FindComponent<EditDoseDialog>();
         await doseEditor.Find("input").InputAsync("");
@@ -355,8 +352,7 @@
         cut.FindAll(".mud-toggle-item")[0].ClassList.Should().Contain("mud-toggle-item-selected");
 
         // Change dose via dialog.
-        // Keep sync: the click handler awaits the dialog result; ClickAsync would block until the dialog closes.
-        cut.Find(".mud-link").Click();
+        cut.Find(".mud-link").Click(); // Keep sync: the click handler awaits the dialog result; ClickAsync would block until the dialog closes.
         await layout.WaitForAssertionAsync(() => layout.HasComponent<EditDoseDialog>().Should().BeTrue());
         doseEditor = layout.FindComponent<EditDoseDialog>();
         await doseEditor.Find("input").InputAsync("99");
@@ -367,8 +363,7 @@
         cut.FindAll(".mud-toggle-item")[1].ClassList.Should().Contain("mud-toggle-item-selected");
 
         // Cancel dialog.
-        // Keep sync: the click handler awaits the dialog result; ClickAsync would block until the dialog closes.
-        cut.Find(".mud-link").Click();
+        cut.Find(".mud-link").Click(); // Keep sync: the click handler awaits the dialog result; ClickAsync would block until the dialog closes.
         await layout.WaitForAssertionAsync(() => layout.HasComponent<EditDoseDialog>().Should().BeTrue());
         doseEditor = layout.FindComponent<EditDoseDialog>();
         await doseEditor.Find("input").InputAsync("88");
@@ -432,15 +427,13 @@
         layout.FindAll(".mud-dialog").Count.Should().Be(0);
 
         // Submit.
-        // Keep sync: the click handler awaits the dialog result; ClickAsync would block until the dialog closes.
-        cut.Find(".mud-link").Click();
+        cut.Find(".mud-link").Click(); // Keep sync: the click handler awaits the dialog result; ClickAsync would block until the dialog closes.
         await layout.WaitForAssertionAsync(() => layout.FindAll(".mud-dialog").Count.Should().Be(1));
         await layout.Find(".submit-button").ClickAsync();
         await layout.WaitForAssertionAsync(() => layout.FindAll(".mud-dialog").Count.Should().Be(0));
 
         // Cancel.
-        // Keep sync: the click handler awaits the dialog result; ClickAsync would block until the dialog closes.
-        cut.Find(".mud-link").Click();
+        cut.Find(".mud-link").Click(); // Keep sync: the click handler awaits the dialog result; ClickAsync would block until the dialog closes.
         await layout.WaitForAssertionAsync(() => layout.FindAll(".mud-dialog").Count.Should().Be(1));
         await layout.Find(".cancel-button").ClickAsync();
         await layout.WaitForAssertionAsync(() => layout.FindAll(".mud-dialog").Count.Should().Be(0));
@@ -494,8 +487,7 @@
 
         var cut = layout.FindComponent<DataPointView>();
 
-        // Keep sync: the click handler awaits the dialog result; ClickAsync would block until the dialog closes.
-        cut.Find("button[aria-label='Edit note']").Click();
+        cut.Find("button[aria-label='Edit note']").Click(); // Keep sync: the click handler awaits the dialog result; ClickAsync would block until the dialog closes.
         await layout.WaitForAssertionAsync(() => layout.HasComponent<EditNoteDialog>().Should().BeTrue());
         await layout.FindComponent<EditNoteDialog>().Find("textarea").InputAsync("Updated");
         await layout.Find(".submit-button").ClickAsync();

--- a/JournalApp.Tests/IndexTests.razor
+++ b/JournalApp.Tests/IndexTests.razor
@@ -11,7 +11,7 @@
     }
 
     [Fact]
-    public void CanSwitchDays()
+    public async Task CanSwitchDays()
     {
         var layout = Render(
     @<MainLayout>
@@ -26,15 +26,15 @@
 
         selectedDayNumber().Should().Be(nowDayNumber);
 
-        layout.Find(".day-switcher-back").Click();
+        await layout.Find(".day-switcher-back").ClickAsync();
         selectedDayNumber().Should().Be(nowDayNumber - 1);
 
-        layout.Find(".day-switcher-forward").Click();
+        await layout.Find(".day-switcher-forward").ClickAsync();
         selectedDayNumber().Should().Be(nowDayNumber);
     }
 
     [Fact]
-    public void CannotGoPastTomorrow()
+    public async Task CannotGoPastTomorrow()
     {
         var layout = Render(
     @<MainLayout>
@@ -49,17 +49,17 @@
 
         // We can go to tomorrow.
         layout.Find(".day-switcher-forward").HasAttribute("disabled").Should().BeFalse();
-        layout.Find(".day-switcher-forward").Click();
+        await layout.Find(".day-switcher-forward").ClickAsync();
         selectedDayNumber().Should().Be(nowDayNumber + 1);
 
         // We cannot go past tomorrow
         layout.Find(".day-switcher-forward").HasAttribute("disabled").Should().BeTrue();
-        layout.Find(".day-switcher-forward").Click();
+        await layout.Find(".day-switcher-forward").ClickAsync();
         selectedDayNumber().Should().Be(nowDayNumber + 1);
     }
 
     [Fact]
-    public void DataIsSavedWhileSwitchingDays()
+    public async Task DataIsSavedWhileSwitchingDays()
     {
         var dbf = Services.GetService<IDbContextFactory<AppDbContext>>();
         const string weightCategoryGuid = "480dc07d-1330-486f-9b30-ec83a3d4e6f0";
@@ -78,13 +78,13 @@
         var weightInput = () => layout.Find($".data-point-container[data-category-guid=\"{weightCategoryGuid}\"] .data-point-view input");
 
         // Change the value so we can test if it is saved. -1 will never be chosen randomly.
-        weightInput().Input("-1");
+        await weightInput().InputAsync("-1");
         weightInput().GetAttribute("value").Should().Be("-1");
 
         // Go back to trigger save of current day state.
-        layout.Find(".day-switcher-back").Click();
-        layout.WaitForAssertion(() => selectedDayNumber().Should().Be(originalDayNumber - 1));
-        layout.WaitForAssertion(() => weightInput().GetAttribute("value").Should().NotBe("-1"));
+        await layout.Find(".day-switcher-back").ClickAsync();
+        await layout.WaitForAssertionAsync(() => selectedDayNumber().Should().Be(originalDayNumber - 1));
+        await layout.WaitForAssertionAsync(() => weightInput().GetAttribute("value").Should().NotBe("-1"));
 
         // Validate persistence in a fresh db context, not just the currently tracked entity.
         using (var db = dbf.CreateDbContext())
@@ -95,11 +95,11 @@
         }
 
         // Return to original day and ensure UI reflects saved value.
-        layout.Find(".day-switcher-forward").Click();
-        layout.WaitForAssertion(() => selectedDayNumber().Should().Be(originalDayNumber));
+        await layout.Find(".day-switcher-forward").ClickAsync();
+        await layout.WaitForAssertionAsync(() => selectedDayNumber().Should().Be(originalDayNumber));
 
         // Assert that the weight is back to it's changed value from the original day.
-        layout.WaitForAssertion(() => weightInput().GetAttribute("value").Should().Be("-1"));
+        await layout.WaitForAssertionAsync(() => weightInput().GetAttribute("value").Should().Be("-1"));
     }
 
     [Theory]

--- a/JournalApp.Tests/ManageCategoriesTests.razor
+++ b/JournalApp.Tests/ManageCategoriesTests.razor
@@ -31,6 +31,7 @@
         }
 
         layout.Find($"#manage-category-{guid} > .manage-category-edit-button").HasAttribute("disabled").Should().BeFalse();
+        // Keep sync: the click handler awaits the dialog result; ClickAsync would block until the dialog closes.
         layout.Find($"#manage-category-{guid} > .manage-category-edit-button").Click();
         await layout.WaitForAssertionAsync(() => layout.HasComponent<EditCategoryDialog>().Should().BeTrue());
         var editDialog = layout.FindComponent<EditCategoryDialog>();
@@ -57,7 +58,7 @@
         );
 
         layout.Find($"#manage-category-{guid} > .manage-category-edit-button").HasAttribute("disabled").Should().BeTrue();
-        layout.Find($"#manage-category-{guid} > .manage-category-edit-button").Click();
+        await layout.Find($"#manage-category-{guid} > .manage-category-edit-button").ClickAsync();
         layout.HasComponent<EditCategoryDialog>().Should().BeFalse();
     }
 
@@ -76,7 +77,7 @@
         );
 
         layout.Find($"#manage-category-{guid} > .manage-category-edit-button").HasAttribute("disabled").Should().BeTrue();
-        layout.Find($"#manage-category-{guid} > .manage-category-edit-button").Click();
+        await layout.Find($"#manage-category-{guid} > .manage-category-edit-button").ClickAsync();
         layout.HasComponent<EditCategoryDialog>().Should().BeFalse();
     }
 
@@ -100,6 +101,7 @@
             return db.Categories.Single(c => c.Guid == new Guid(guid));
         }
 
+        // Keep sync: the click handler awaits the dialog result; ClickAsync would block until the dialog closes.
         layout.Find($"#manage-category-{guid} > .manage-category-edit-button").Click();
         await layout.WaitForAssertionAsync(() => layout.HasComponent<EditCategoryDialog>().Should().BeTrue());
 
@@ -138,9 +140,11 @@
 
         var initialCount = layout.FindAll(".manage-category-edit-button").Count;
 
+        // Keep sync: the click handler awaits the dialog result; ClickAsync would block until the dialog closes.
         layout.Find($"#manage-category-{guid} > .manage-category-edit-button").Click();
         await layout.WaitForAssertionAsync(() => layout.HasComponent<EditCategoryDialog>().Should().BeTrue());
 
+        // Keep sync: the click handler awaits the message box result; ClickAsync would block until it closes.
         layout.Find(".category-dialog .delete-button").Click();
         await layout.WaitForAssertionAsync(() => layout.Find(".mud-message-box__yes-button"));
         await layout.Find(".mud-message-box__yes-button").ClickAsync();
@@ -169,6 +173,7 @@
         var initialCount = layout.FindAll(".manage-category-edit-button").Count;
 
         // Open the dialog to create a new category.
+        // Keep sync: the click handler awaits the dialog result; ClickAsync would block until the dialog closes.
         layout.Find(".add-category-button").Click();
         await layout.WaitForAssertionAsync(() => layout.Markup.Should().Contain("New element"));
 
@@ -194,6 +199,7 @@
         var initialCount = layout.FindAll(".manage-category-edit-button").Count;
 
         // Open the dialog to create a new category.
+        // Keep sync: the click handler awaits the dialog result; ClickAsync would block until the dialog closes.
         layout.Find(".add-category-button").Click();
         await layout.WaitForAssertionAsync(() => layout.Markup.Should().Contain("New medication"));
 

--- a/JournalApp.Tests/ManageCategoriesTests.razor
+++ b/JournalApp.Tests/ManageCategoriesTests.razor
@@ -11,7 +11,7 @@
     }
 
     [Fact]
-    public void EditDialog_Open()
+    public async Task EditDialog_Open()
     {
         var dbf = Services.GetService<IDbContextFactory<AppDbContext>>();
         var guid = "de394b38-9007-4349-ae31-429541aab947"; // Physical activity.
@@ -32,18 +32,18 @@
 
         layout.Find($"#manage-category-{guid} > .manage-category-edit-button").HasAttribute("disabled").Should().BeFalse();
         layout.Find($"#manage-category-{guid} > .manage-category-edit-button").Click();
-        layout.WaitForAssertion(() => layout.HasComponent<EditCategoryDialog>().Should().BeTrue());
+        await layout.WaitForAssertionAsync(() => layout.HasComponent<EditCategoryDialog>().Should().BeTrue());
         var editDialog = layout.FindComponent<EditCategoryDialog>();
 
         // Assert.
         Category().Name.Should().Be("Physical activity");
         editDialog.FindAll(".mud-input-text input")[0].GetAttribute("value").Should().Be("Physical activity");
 
-        layout.Find(".submit-button").Click();
+        await layout.Find(".submit-button").ClickAsync();
     }
 
     [Fact]
-    public void EditDialog_ShouldNotOpenWhenCategoryIsDisabled()
+    public async Task EditDialog_ShouldNotOpenWhenCategoryIsDisabled()
     {
         var dbf = Services.GetService<IDbContextFactory<AppDbContext>>();
         var guid = "0fb54aff-9ecc-4c17-bab5-b908b794cea9"; // Anxiety.
@@ -62,7 +62,7 @@
     }
 
     [Fact]
-    public void EditDialog_ShouldNotOpenWhenCategoryIsReadOnly()
+    public async Task EditDialog_ShouldNotOpenWhenCategoryIsReadOnly()
     {
         var dbf = Services.GetService<IDbContextFactory<AppDbContext>>();
         var guid = "d90d89fb-f5b9-47cf-ae4e-3ec0d635e783"; // Overall mood.
@@ -81,7 +81,7 @@
     }
 
     [Fact]
-    public void EditDialog_UpdatesList()
+    public async Task EditDialog_UpdatesList()
     {
         var dbf = Services.GetService<IDbContextFactory<AppDbContext>>();
         var guid = "de394b38-9007-4349-ae31-429541aab947"; // Physical activity.
@@ -101,18 +101,18 @@
         }
 
         layout.Find($"#manage-category-{guid} > .manage-category-edit-button").Click();
-        layout.WaitForAssertion(() => layout.HasComponent<EditCategoryDialog>().Should().BeTrue());
+        await layout.WaitForAssertionAsync(() => layout.HasComponent<EditCategoryDialog>().Should().BeTrue());
 
         Category().Name.Should().Be("Physical activity");
-        layout.FindAll(".category-dialog .mud-input-text input")[0].Input("New name");
+        await layout.FindAll(".category-dialog .mud-input-text input")[0].InputAsync("New name");
 
         // Submit changes and confirm they have changed on the main list.
-        layout.Find(".category-dialog .submit-button").Click();
+        await layout.Find(".category-dialog .submit-button").ClickAsync();
         layout.Find($"#manage-category-{guid} > .manage-category-edit-button").TextContent.Should().Be("New name");
     }
 
     [Fact]
-    public void EditDialog_Delete()
+    public async Task EditDialog_Delete()
     {
         var dbf = Services.GetService<IDbContextFactory<AppDbContext>>();
         var guid = "de394b38-9007-4349-ae31-429541aab947"; // Physical activity.
@@ -139,14 +139,14 @@
         var initialCount = layout.FindAll(".manage-category-edit-button").Count;
 
         layout.Find($"#manage-category-{guid} > .manage-category-edit-button").Click();
-        layout.WaitForAssertion(() => layout.HasComponent<EditCategoryDialog>().Should().BeTrue());
+        await layout.WaitForAssertionAsync(() => layout.HasComponent<EditCategoryDialog>().Should().BeTrue());
 
         layout.Find(".category-dialog .delete-button").Click();
-        layout.WaitForAssertion(() => layout.Find(".mud-message-box__yes-button"));
-        layout.Find(".mud-message-box__yes-button").Click();
+        await layout.WaitForAssertionAsync(() => layout.Find(".mud-message-box__yes-button"));
+        await layout.Find(".mud-message-box__yes-button").ClickAsync();
 
-        layout.WaitForAssertion(() => layout.HasComponent<EditCategoryDialog>().Should().BeFalse());
-        layout.WaitForAssertion(() => layout.FindAll(".manage-category-edit-button").Count.Should().Be(initialCount - 1));
+        await layout.WaitForAssertionAsync(() => layout.HasComponent<EditCategoryDialog>().Should().BeFalse());
+        await layout.WaitForAssertionAsync(() => layout.FindAll(".manage-category-edit-button").Count.Should().Be(initialCount - 1));
 
         using (var db = dbf.CreateDbContext())
         {
@@ -156,7 +156,7 @@
     }
 
     [Fact]
-    public void AddNewCategory()
+    public async Task AddNewCategory()
     {
         var layout = Render(
     @<MainLayout>
@@ -170,18 +170,18 @@
 
         // Open the dialog to create a new category.
         layout.Find(".add-category-button").Click();
-        layout.WaitForAssertion(() => layout.Markup.Should().Contain("New element"));
+        await layout.WaitForAssertionAsync(() => layout.Markup.Should().Contain("New element"));
 
         // Set up the new category.
-        layout.FindAll(".category-dialog .mud-input-text input")[0].Input("New name");
+        await layout.FindAll(".category-dialog .mud-input-text input")[0].InputAsync("New name");
 
         // Submit changes and confirm there is a new category in the list.
-        layout.Find(".category-dialog .submit-button").Click();
-        layout.WaitForAssertion(() => layout.FindAll(".manage-category-edit-button").Count.Should().Be(initialCount + 1));
+        await layout.Find(".category-dialog .submit-button").ClickAsync();
+        await layout.WaitForAssertionAsync(() => layout.FindAll(".manage-category-edit-button").Count.Should().Be(initialCount + 1));
     }
 
     [Fact]
-    public void AddNewMedication()
+    public async Task AddNewMedication()
     {
         var layout = Render(
     @<MainLayout>
@@ -195,14 +195,14 @@
 
         // Open the dialog to create a new category.
         layout.Find(".add-category-button").Click();
-        layout.WaitForAssertion(() => layout.Markup.Should().Contain("New medication"));
+        await layout.WaitForAssertionAsync(() => layout.Markup.Should().Contain("New medication"));
 
         // Set up the new category.
-        layout.FindAll(".category-dialog .mud-input-text input")[0].Input("New name");
+        await layout.FindAll(".category-dialog .mud-input-text input")[0].InputAsync("New name");
 
         // Submit changes and confirm there is a new category in the list.
-        layout.Find(".category-dialog .submit-button").Click();
-        layout.WaitForAssertion(() => layout.FindAll(".manage-category-edit-button").Count.Should().Be(initialCount + 1));
+        await layout.Find(".category-dialog .submit-button").ClickAsync();
+        await layout.WaitForAssertionAsync(() => layout.FindAll(".manage-category-edit-button").Count.Should().Be(initialCount + 1));
     }
 
     [Fact]
@@ -216,7 +216,7 @@
     }
 
     [Fact]
-    public void CanChangeEnabled()
+    public async Task CanChangeEnabled()
     {
         var dbf = Services.GetService<IDbContextFactory<AppDbContext>>();
         var guid = "0fb54aff-9ecc-4c17-bab5-b908b794cea9"; // Anxiety.
@@ -230,14 +230,14 @@
         var cut = Render(@<ManageCategoriesPage />);
 
         Category().Enabled.Should().BeFalse();
-        cut.Find($"#manage-category-{guid} > .manage-category-enabled-switch input").Change(true);
+        await cut.Find($"#manage-category-{guid} > .manage-category-enabled-switch input").ChangeAsync(true);
         Category().Enabled.Should().BeTrue();
-        cut.Find($"#manage-category-{guid} > .manage-category-enabled-switch input").Change(false);
+        await cut.Find($"#manage-category-{guid} > .manage-category-enabled-switch input").ChangeAsync(false);
         Category().Enabled.Should().BeFalse();
     }
 
     [Fact]
-    public void MoveUpToTop()
+    public async Task MoveUpToTop()
     {
         var dbf = Services.GetService<IDbContextFactory<AppDbContext>>();
         var guid = "0fb54aff-9ecc-4c17-bab5-b908b794cea9"; // Anxiety.
@@ -252,7 +252,7 @@
 
         for (int i = 6; i > 1; i--)
         {
-            cut.Find($"#manage-category-{guid} > .manage-category-up-button").Click();
+            await cut.Find($"#manage-category-{guid} > .manage-category-up-button").ClickAsync();
             Category().Index.Should().Be(i - 1);
         }
 

--- a/JournalApp.Tests/ManageCategoriesTests.razor
+++ b/JournalApp.Tests/ManageCategoriesTests.razor
@@ -31,8 +31,7 @@
         }
 
         layout.Find($"#manage-category-{guid} > .manage-category-edit-button").HasAttribute("disabled").Should().BeFalse();
-        // Keep sync: the click handler awaits the dialog result; ClickAsync would block until the dialog closes.
-        layout.Find($"#manage-category-{guid} > .manage-category-edit-button").Click();
+        layout.Find($"#manage-category-{guid} > .manage-category-edit-button").Click(); // Keep sync: the click handler awaits the dialog result; ClickAsync would block until the dialog closes.
         await layout.WaitForAssertionAsync(() => layout.HasComponent<EditCategoryDialog>().Should().BeTrue());
         var editDialog = layout.FindComponent<EditCategoryDialog>();
 
@@ -101,8 +100,7 @@
             return db.Categories.Single(c => c.Guid == new Guid(guid));
         }
 
-        // Keep sync: the click handler awaits the dialog result; ClickAsync would block until the dialog closes.
-        layout.Find($"#manage-category-{guid} > .manage-category-edit-button").Click();
+        layout.Find($"#manage-category-{guid} > .manage-category-edit-button").Click(); // Keep sync: the click handler awaits the dialog result; ClickAsync would block until the dialog closes.
         await layout.WaitForAssertionAsync(() => layout.HasComponent<EditCategoryDialog>().Should().BeTrue());
 
         Category().Name.Should().Be("Physical activity");
@@ -140,12 +138,10 @@
 
         var initialCount = layout.FindAll(".manage-category-edit-button").Count;
 
-        // Keep sync: the click handler awaits the dialog result; ClickAsync would block until the dialog closes.
-        layout.Find($"#manage-category-{guid} > .manage-category-edit-button").Click();
+        layout.Find($"#manage-category-{guid} > .manage-category-edit-button").Click(); // Keep sync: the click handler awaits the dialog result; ClickAsync would block until the dialog closes.
         await layout.WaitForAssertionAsync(() => layout.HasComponent<EditCategoryDialog>().Should().BeTrue());
 
-        // Keep sync: the click handler awaits the message box result; ClickAsync would block until it closes.
-        layout.Find(".category-dialog .delete-button").Click();
+        layout.Find(".category-dialog .delete-button").Click(); // Keep sync: the click handler awaits the message box result; ClickAsync would block until it closes.
         await layout.WaitForAssertionAsync(() => layout.Find(".mud-message-box__yes-button"));
         await layout.Find(".mud-message-box__yes-button").ClickAsync();
 
@@ -173,8 +169,7 @@
         var initialCount = layout.FindAll(".manage-category-edit-button").Count;
 
         // Open the dialog to create a new category.
-        // Keep sync: the click handler awaits the dialog result; ClickAsync would block until the dialog closes.
-        layout.Find(".add-category-button").Click();
+        layout.Find(".add-category-button").Click(); // Keep sync: the click handler awaits the dialog result; ClickAsync would block until the dialog closes.
         await layout.WaitForAssertionAsync(() => layout.Markup.Should().Contain("New element"));
 
         // Set up the new category.
@@ -199,8 +194,7 @@
         var initialCount = layout.FindAll(".manage-category-edit-button").Count;
 
         // Open the dialog to create a new category.
-        // Keep sync: the click handler awaits the dialog result; ClickAsync would block until the dialog closes.
-        layout.Find(".add-category-button").Click();
+        layout.Find(".add-category-button").Click(); // Keep sync: the click handler awaits the dialog result; ClickAsync would block until the dialog closes.
         await layout.WaitForAssertionAsync(() => layout.Markup.Should().Contain("New medication"));
 
         // Set up the new category.

--- a/JournalApp.Tests/SafetyPlanTests.razor
+++ b/JournalApp.Tests/SafetyPlanTests.razor
@@ -38,7 +38,7 @@
         cut.Find(".safety-plan-item-purpose textarea").TextContent.Should().Be("My purpose is to finish these tests");
 
         // Change via textarea and property to test both.
-        cut.Find(".safety-plan-item-purpose textarea").Input("Actually it's puppies");
+        await cut.Find(".safety-plan-item-purpose textarea").InputAsync("Actually it's puppies");
         cut.Instance.Plan.ProfessionalContacts = "988 (USA)";
 
         // Leave and come back.


### PR DESCRIPTION
Updates bUnit test interactions to use async dispatch APIs where they can complete normally, including `ClickAsync`, `InputAsync`, `ChangeAsync`, and `WaitForAssertionAsync`.

A few dialog-opening clicks remain synchronous with comments because those handlers await dialog or message-box results, so `ClickAsync` would block until the dialog closes and hang the test.
