### PR TITLE
Rework test suite

### DIFF
--- a/JournalApp.Tests/Data/AppDataServiceTests.cs
+++ b/JournalApp.Tests/Data/AppDataServiceTests.cs
@@ -113,14 +113,6 @@ public class AppDataServiceTests : JaTestContext
         }
     }
 
-    [Fact(Skip = "SQLite doesn't enforce all constraints that would trigger rollback in production")]
-    public async Task ReplaceDbSets_IsAtomic_RollsBackOnError()
-    {
-        // This test is skipped because SQLite's constraint enforcement differs from production databases.
-        // The atomicity of ReplaceDbSets is already validated by ReplaceDbSets_DeletesOldDataAndRestoresNewData
-        // which ensures both delete and restore happen in a single transaction.
-    }
-
     [Fact]
     public async Task CreateBackup_CapturesAllData()
     {
@@ -194,57 +186,38 @@ public class AppDataServiceTests : JaTestContext
         preferenceBackups.Should().Contain(pb => pb.Name == "mood_palette" && pb.Value == "Test palette");
     }
 
-    [Fact]
-    public void SetPreferences_RestoresPreferencesFromBackup()
+    public static TheoryData<PreferenceBackup[]> SetPreferencesCases()
     {
-        // Arrange
-        var preferences = Services.GetService<IPreferences>();
-        var appDataService = Services.GetService<AppDataService>();
-
-        var backup = new BackupFile
-        {
-            PreferenceBackups =
-            [
-                new("safety_plan", "Restored plan"),
-                new("mood_palette", "Restored palette")
-            ]
-        };
-
-        // Act
-        appDataService.SetPreferences(backup);
-
-        // Assert
-        preferences.Get<string>("safety_plan", null).Should().Be("Restored plan");
-        preferences.Get<string>("mood_palette", null).Should().Be("Restored palette");
+        var cases = new TheoryData<PreferenceBackup[]>();
+        cases.Add([new("safety_plan", "Restored plan"), new("mood_palette", "Restored palette")]);
+        cases.Add([]); // empty backup
+        return cases;
     }
 
-    [Fact]
-    public void SetPreferences_ClearsUnrelatedUserPreferences()
+    [Theory]
+    [MemberData(nameof(SetPreferencesCases))]
+    public void SetPreferences_RestoresBackupKeysAndClearsUnrelatedPreferences(PreferenceBackup[] backups)
     {
         // Arrange
         var preferences = Services.GetService<IPreferences>();
         var appDataService = Services.GetService<AppDataService>();
 
+        // Pre-existing user preferences that are not part of the backup.
         preferences.Set("theme", AppTheme.Dark.ToString());
         preferences.Set("hide_notes", true);
 
-        var backup = new BackupFile
-        {
-            PreferenceBackups =
-            [
-                new("safety_plan", "Restored plan"),
-                new("mood_palette", "Restored palette")
-            ]
-        };
+        var backup = new BackupFile { PreferenceBackups = backups };
 
         // Act
         appDataService.SetPreferences(backup);
 
-        // Assert
-        preferences.Get<string>("safety_plan", null).Should().Be("Restored plan");
-        preferences.Get<string>("mood_palette", null).Should().Be("Restored palette");
+        // Assert - restore is a full overwrite: unrelated preferences are always cleared...
         preferences.Get<string>("theme", null).Should().BeNull();
         preferences.Get("hide_notes", false).Should().BeFalse();
+
+        // ...and the backup's keys are restored verbatim.
+        foreach (var expected in backups)
+            preferences.Get<string>(expected.Name, null).Should().Be(expected.Value);
     }
 
     [Fact]
@@ -333,6 +306,7 @@ public class AppDataServiceTests : JaTestContext
             point.Text = "Test note";
             point.Number = 42;
             point.Bool = true;
+            point.Deleted = true; // the soft-delete flag must survive the round-trip too
 
             db.Points.Add(point);
             await db.SaveChangesAsync();
@@ -352,6 +326,7 @@ public class AppDataServiceTests : JaTestContext
             restoredPoint.Text.Should().Be("Test note");
             restoredPoint.Number.Should().Be(42);
             restoredPoint.Bool.Should().BeTrue();
+            restoredPoint.Deleted.Should().BeTrue();
         }
     }
 
@@ -398,32 +373,6 @@ public class AppDataServiceTests : JaTestContext
             restoredCategory.MedicationEveryDaySince.Should().NotBeNull();
             restoredCategory.Details.Should().Be("Test details");
         }
-    }
-
-    [Fact]
-    public async Task CreateBackup_WithLargeDataset_CompletesSuccessfully()
-    {
-        // Arrange
-        var dbFactory = Services.GetService<IDbContextFactory<AppDbContext>>();
-        var appDbSeeder = Services.GetService<AppDbSeeder>();
-        var appDataService = Services.GetService<AppDataService>();
-
-        appDbSeeder.SeedCategories();
-
-        // Create a large dataset - full year of data (2024 is a leap year with 366 days)
-        var startDate = new DateOnly(2024, 1, 1);
-        var endDate = new DateOnly(2024, 12, 31);
-        var dates = startDate.DatesTo(endDate);
-        appDbSeeder.SeedDays(dates);
-
-        // Act
-        var backup = await appDataService.CreateBackup();
-
-        // Assert
-        backup.Should().NotBeNull();
-        backup.Days.Should().HaveCount(366); // 2024 is a leap year
-        backup.Points.Should().NotBeEmpty();
-        backup.Categories.Should().NotBeEmpty();
     }
 
     [Fact]
@@ -537,66 +486,6 @@ public class AppDataServiceTests : JaTestContext
 
         // Assert - Deleted items should be included in backup
         backup.Points.Should().Contain(p => p.Deleted);
-    }
-
-    [Fact]
-    public async Task RestoreDbSets_PreservesDeletedFlag()
-    {
-        // Arrange
-        var dbFactory = Services.GetService<IDbContextFactory<AppDbContext>>();
-        var appDbSeeder = Services.GetService<AppDbSeeder>();
-        var appDataService = Services.GetService<AppDataService>();
-
-        appDbSeeder.SeedCategories();
-
-        using (var db = await dbFactory.CreateDbContextAsync())
-        {
-            var day = Day.Create(new DateOnly(2024, 1, 1));
-            db.Days.Add(day);
-
-            var category = db.Categories.First();
-            var point = DataPoint.Create(day, category);
-            point.Deleted = true;
-
-            db.Points.Add(point);
-            await db.SaveChangesAsync();
-        }
-
-        var backup = await appDataService.CreateBackup();
-        await appDataService.DeleteDbSets();
-
-        // Act
-        await appDataService.RestoreDbSets(backup);
-
-        // Assert
-        using (var db = await dbFactory.CreateDbContextAsync())
-        {
-            var restoredPoint = db.Points.First();
-            restoredPoint.Deleted.Should().BeTrue();
-        }
-    }
-
-    [Fact]
-    public void SetPreferences_WithEmptyBackup_ClearsExistingPreferences()
-    {
-        // Arrange
-        var preferences = Services.GetService<IPreferences>();
-        var appDataService = Services.GetService<AppDataService>();
-
-        preferences.Set("theme", AppTheme.Dark.ToString());
-        preferences.Set("hide_notes", true);
-
-        var backup = new BackupFile
-        {
-            PreferenceBackups = []
-        };
-
-        // Act
-        appDataService.SetPreferences(backup);
-
-        // Assert
-        preferences.Get<string>("theme", null).Should().BeNull();
-        preferences.Get("hide_notes", false).Should().BeFalse();
     }
 
     [Fact]

--- a/JournalApp.Tests/Data/AppDataUIServiceTests.cs
+++ b/JournalApp.Tests/Data/AppDataUIServiceTests.cs
@@ -220,6 +220,137 @@ public class AppDataUIServiceTests : JaTestContext
             .Which.Should().Contain("Export failed: disk full");
     }
 
+    [Fact]
+    public async Task StartImportWizard_AbortsAtBackupWarning_WhenExportStaleAndUserGoesBack()
+    {
+        // Arrange
+        var dbFactory = Services.GetService<IDbContextFactory<AppDbContext>>();
+        var appDbSeeder = Services.GetService<AppDbSeeder>();
+        var appDataService = Services.GetService<AppDataService>();
+        var preferenceService = Services.GetService<PreferenceService>();
+
+        // A stale export (well over a week ago) triggers the "back up first" recommendation.
+        preferenceService.LastExportDate = new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+        appDbSeeder.SeedCategories();
+        var originalDates = new DateOnly(2024, 1, 1).DatesTo(new(2024, 1, 3));
+        appDbSeeder.SeedDays(originalDates);
+
+        var importPath = Path.Combine(Path.GetTempPath(), $"stale-goback-{Guid.NewGuid()}.journalapp");
+        await CreateBackup(new DateOnly(2024, 2, 1), "Imported plan", "imported-palette").WriteArchive(importPath);
+
+        var dialogService = new TestDialogService([null]); // user picks "Go back" at the warning
+        var service = new AppDataUIService(
+            NullLogger<AppDataUIService>.Instance,
+            appDataService,
+            new TestFileSaver(),
+            preferenceService);
+
+        try
+        {
+            // Act
+            var imported = await service.StartImportWizard(dialogService, importPath);
+
+            // Assert - aborts before reading the archive or showing the replace-all confirmation.
+            imported.Should().BeFalse();
+            dialogService.Messages.Should().ContainSingle().Which.Should().Contain("Recommended: Back up");
+            dialogService.Messages.Should().NotContain(message => message.Contains("replace ALL current data"));
+
+            using var db = await dbFactory.CreateDbContextAsync();
+            db.Days.Should().HaveCount(originalDates.Count());
+        }
+        finally
+        {
+            File.Delete(importPath);
+        }
+    }
+
+    [Fact]
+    public async Task StartImportWizard_CompletesImport_WhenExportStaleAndUserContinues()
+    {
+        // Arrange
+        var dbFactory = Services.GetService<IDbContextFactory<AppDbContext>>();
+        var appDbSeeder = Services.GetService<AppDbSeeder>();
+        var appDataService = Services.GetService<AppDataService>();
+        var preferenceService = Services.GetService<PreferenceService>();
+        var preferences = Services.GetService<IPreferences>();
+
+        var staleExportDate = new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        preferenceService.LastExportDate = staleExportDate;
+
+        appDbSeeder.SeedCategories();
+        appDbSeeder.SeedDays(new DateOnly(2024, 1, 1).DatesTo(new(2024, 1, 3)));
+
+        var importPath = Path.Combine(Path.GetTempPath(), $"stale-continue-{Guid.NewGuid()}.journalapp");
+        await CreateBackup(new DateOnly(2024, 2, 1), "Imported plan", "imported-palette").WriteArchive(importPath);
+
+        // Continue past the backup warning, then confirm the replace. This is the only end-to-end success path.
+        var dialogService = new TestDialogService([true, true]);
+        var service = new AppDataUIService(
+            NullLogger<AppDataUIService>.Instance,
+            appDataService,
+            new TestFileSaver(),
+            preferenceService);
+
+        try
+        {
+            // Act
+            var imported = await service.StartImportWizard(dialogService, importPath);
+
+            // Assert
+            imported.Should().BeTrue();
+
+            using (var db = await dbFactory.CreateDbContextAsync())
+            {
+                db.Days.Should().ContainSingle(day => day.Date == new DateOnly(2024, 2, 1));
+                db.Days.Should().NotContain(day => day.Date == new DateOnly(2024, 1, 1));
+            }
+
+            preferences.Get<string>("safety_plan", null).Should().Be("Imported plan");
+            preferenceService.LastExportDate.Should().BeAfter(staleExportDate);
+        }
+        finally
+        {
+            File.Delete(importPath);
+        }
+    }
+
+    [Fact]
+    public async Task StartImportWizard_ShowsImportFailed_WhenArchiveInvalid_WithoutShowingConfirmation()
+    {
+        // Arrange
+        var appDataService = Services.GetService<AppDataService>();
+        var preferenceService = Services.GetService<PreferenceService>();
+
+        // Future export date skips the backup warning so this test isolates the read-archive failure branch.
+        preferenceService.LastExportDate = new DateTimeOffset(2099, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+        var invalidPath = Path.Combine(Path.GetTempPath(), $"invalid-import-{Guid.NewGuid()}.journalapp");
+        await File.WriteAllTextAsync(invalidPath, "this is not a zip");
+
+        var dialogService = new TestDialogService();
+        var service = new AppDataUIService(
+            NullLogger<AppDataUIService>.Instance,
+            appDataService,
+            new TestFileSaver(),
+            preferenceService);
+
+        try
+        {
+            // Act
+            var imported = await service.StartImportWizard(dialogService, invalidPath);
+
+            // Assert - fails on read, before the replace-all confirmation is ever shown.
+            imported.Should().BeFalse();
+            dialogService.Messages.Should().Contain(message => message.StartsWith("Import failed:"));
+            dialogService.Messages.Should().NotContain(message => message.Contains("replace ALL current data"));
+        }
+        finally
+        {
+            File.Delete(invalidPath);
+        }
+    }
+
     private static BackupFile CreateBackup(DateOnly date, string safetyPlan, string moodPalette)
     {
         var day = Day.Create(date);

--- a/JournalApp.Tests/Data/AppDbContextTests.cs
+++ b/JournalApp.Tests/Data/AppDbContextTests.cs
@@ -82,8 +82,10 @@ public class AppDbContextTests : JaTestContext
         }
     }
 
-    [Fact]
-    public async Task GetOrCreateDayAndAddPoints_DoesNotAddPointsForDisabledCategories()
+    [Theory]
+    [InlineData(true, false)]  // disabled
+    [InlineData(false, true)]  // deleted
+    public async Task GetOrCreateDayAndAddPoints_DoesNotAddPointsForInactiveCategories(bool disabled, bool deleted)
     {
         // Arrange
         var dbFactory = Services.GetService<IDbContextFactory<AppDbContext>>();
@@ -92,9 +94,9 @@ public class AppDbContextTests : JaTestContext
 
         using var db = await dbFactory.CreateDbContextAsync();
 
-        // Disable a category
-        var categoryToDisable = db.Categories.First(c => c.Enabled && !c.Deleted);
-        categoryToDisable.Enabled = false;
+        var target = db.Categories.First(c => c.Enabled && !c.Deleted && c.Group != "Notes");
+        target.Enabled = !disabled;
+        target.Deleted = deleted;
         await db.SaveChangesAsync();
 
         var date = new DateOnly(2024, 1, 1);
@@ -104,36 +106,13 @@ public class AppDbContextTests : JaTestContext
         await db.SaveChangesAsync();
 
         // Assert
-        day.Points.Should().NotContain(p => p.Category.Guid == categoryToDisable.Guid);
+        day.Points.Should().NotContain(p => p.Category.Guid == target.Guid);
     }
 
-    [Fact]
-    public async Task GetOrCreateDayAndAddPoints_DoesNotAddPointsForDeletedCategories()
-    {
-        // Arrange
-        var dbFactory = Services.GetService<IDbContextFactory<AppDbContext>>();
-        var appDbSeeder = Services.GetService<AppDbSeeder>();
-        appDbSeeder.SeedCategories();
-
-        using var db = await dbFactory.CreateDbContextAsync();
-
-        // Delete a category
-        var categoryToDelete = db.Categories.First(c => c.Enabled && !c.Deleted);
-        categoryToDelete.Deleted = true;
-        await db.SaveChangesAsync();
-
-        var date = new DateOnly(2024, 1, 1);
-
-        // Act
-        var day = await db.GetOrCreateDayAndAddPoints(date);
-        await db.SaveChangesAsync();
-
-        // Assert
-        day.Points.Should().NotContain(p => p.Category.Guid == categoryToDelete.Guid);
-    }
-
-    [Fact]
-    public async Task GetMissingPoints_ReturnsEmptySet_WhenCategoryDisabled()
+    [Theory]
+    [InlineData(true, false)]  // disabled
+    [InlineData(false, true)]  // deleted
+    public async Task GetMissingPoints_ReturnsEmptySet_WhenCategoryInactive(bool disabled, bool deleted)
     {
         // Arrange
         var dbFactory = Services.GetService<IDbContextFactory<AppDbContext>>();
@@ -143,33 +122,11 @@ public class AppDbContextTests : JaTestContext
         using var db = await dbFactory.CreateDbContextAsync();
         var day = Day.Create(new DateOnly(2024, 1, 1));
         var category = db.Categories.First();
-        category.Enabled = false;
+        category.Enabled = !disabled;
+        category.Deleted = deleted;
 
-        // Act
-        var missingPoints = db.GetMissingPoints(day, category, null);
-
-        // Assert
-        missingPoints.Should().BeEmpty();
-    }
-
-    [Fact]
-    public async Task GetMissingPoints_ReturnsEmptySet_WhenCategoryDeleted()
-    {
-        // Arrange
-        var dbFactory = Services.GetService<IDbContextFactory<AppDbContext>>();
-        var appDbSeeder = Services.GetService<AppDbSeeder>();
-        appDbSeeder.SeedCategories();
-
-        using var db = await dbFactory.CreateDbContextAsync();
-        var day = Day.Create(new DateOnly(2024, 1, 1));
-        var category = db.Categories.First();
-        category.Deleted = true;
-
-        // Act
-        var missingPoints = db.GetMissingPoints(day, category, null);
-
-        // Assert
-        missingPoints.Should().BeEmpty();
+        // Act & Assert
+        db.GetMissingPoints(day, category, null).Should().BeEmpty();
     }
 
     [Fact]
@@ -216,54 +173,11 @@ public class AppDbContextTests : JaTestContext
         missingPoints.Should().BeEmpty();
     }
 
-    [Fact]
-    public async Task GetMissingPoints_SetsMedicationTaken_WhenEveryDaySinceIsBeforeDate()
-    {
-        // Arrange
-        var dbFactory = Services.GetService<IDbContextFactory<AppDbContext>>();
-        var appDbSeeder = Services.GetService<AppDbSeeder>();
-        appDbSeeder.SeedCategories();
-
-        using var db = await dbFactory.CreateDbContextAsync();
-        var today = DateOnly.FromDateTime(DateTime.Now);
-        var day = Day.Create(today);
-
-        var medicationCategory = db.Categories.First(c => c.Type == PointType.Medication);
-        medicationCategory.MedicationEveryDaySince = DateTime.Now.AddDays(-5);
-
-        // Act
-        var missingPoints = db.GetMissingPoints(day, medicationCategory, null);
-
-        // Assert
-        missingPoints.Should().HaveCount(1);
-        missingPoints.First().Bool.Should().BeTrue();
-    }
-
-    [Fact]
-    public async Task GetMissingPoints_DoesNotSetMedicationTaken_WhenEveryDaySinceIsAfterDate()
-    {
-        // Arrange
-        var dbFactory = Services.GetService<IDbContextFactory<AppDbContext>>();
-        var appDbSeeder = Services.GetService<AppDbSeeder>();
-        appDbSeeder.SeedCategories();
-
-        using var db = await dbFactory.CreateDbContextAsync();
-        var yesterday = DateOnly.FromDateTime(DateTime.Now.AddDays(-1));
-        var day = Day.Create(yesterday);
-
-        var medicationCategory = db.Categories.First(c => c.Type == PointType.Medication);
-        medicationCategory.MedicationEveryDaySince = DateTime.Now; // Today, so yesterday shouldn't be marked
-
-        // Act
-        var missingPoints = db.GetMissingPoints(day, medicationCategory, null);
-
-        // Assert
-        missingPoints.Should().HaveCount(1);
-        missingPoints.First().Bool.Should().NotBe(true);
-    }
-
-    [Fact]
-    public async Task GetMissingPoints_SetsMedicationTaken_WhenEveryDaySinceMatchesDate()
+    [Theory]
+    [InlineData(-5, true)]  // started before this day -> taken
+    [InlineData(0, true)]   // started exactly on this day (inclusive) -> taken
+    [InlineData(1, false)]  // starts after this day -> not taken
+    public async Task GetMissingPoints_MarksMedicationTaken_WhenEveryDaySinceIsOnOrBeforeDate(int sinceOffsetDays, bool expectedTaken)
     {
         // Arrange
         var dbFactory = Services.GetService<IDbContextFactory<AppDbContext>>();
@@ -275,14 +189,17 @@ public class AppDbContextTests : JaTestContext
         var day = Day.Create(date);
 
         var medicationCategory = db.Categories.First(c => c.Type == PointType.Medication);
-        medicationCategory.MedicationEveryDaySince = new DateTimeOffset(date.ToDateTime(TimeOnly.MinValue));
+        medicationCategory.MedicationEveryDaySince = new DateTimeOffset(date.AddDays(sinceOffsetDays).ToDateTime(TimeOnly.MinValue));
 
         // Act
         var missingPoints = db.GetMissingPoints(day, medicationCategory, null);
 
         // Assert
         missingPoints.Should().HaveCount(1);
-        missingPoints.First().Bool.Should().BeTrue();
+        if (expectedTaken)
+            missingPoints.First().Bool.Should().BeTrue();
+        else
+            missingPoints.First().Bool.Should().NotBe(true);
     }
 
     [Fact]
@@ -368,8 +285,8 @@ public class AppDbContextTests : JaTestContext
         db.AddCategory(newCategory);
         await db.SaveChangesAsync();
 
-        // Assert
-        newCategory.Index.Should().BeGreaterThan(0);
+        // Assert - first category in a fresh group gets index 1
+        newCategory.Index.Should().Be(1);
     }
 
     [Fact]

--- a/JournalApp.Tests/Data/CalendarServiceTests.cs
+++ b/JournalApp.Tests/Data/CalendarServiceTests.cs
@@ -1,0 +1,105 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace JournalApp.Tests.Data;
+
+/// <summary>
+/// CalendarService.CreateGridYear loads the year's mood points into a grid. Its compound filter
+/// (not deleted, right year, not in the future, mood category only) and its deliberate tolerance of
+/// duplicate dates are defensive logic that nothing else exercises.
+/// </summary>
+public class CalendarServiceTests : JaTestContext
+{
+    private static readonly Guid MoodCategoryGuid = new("D90D89FB-F5B9-47CF-AE4E-3EC0D635E783");
+
+    public override async Task InitializeAsync()
+    {
+        await base.InitializeAsync();
+        AddDbContext();
+    }
+
+    private async Task AddMoodPoint(DateOnly date, string mood, bool deleted = false)
+    {
+        var dbFactory = Services.GetService<IDbContextFactory<AppDbContext>>();
+        await using var db = await dbFactory.CreateDbContextAsync();
+        var day = Day.Create(date);
+        db.Days.Add(day);
+        var moodCategory = db.Categories.Single(c => c.Guid == MoodCategoryGuid);
+        var point = DataPoint.Create(day, moodCategory);
+        point.Mood = mood;
+        point.Deleted = deleted;
+        db.Points.Add(point);
+        await db.SaveChangesAsync();
+    }
+
+    private async Task AddNonMoodPoint(DateOnly date)
+    {
+        var dbFactory = Services.GetService<IDbContextFactory<AppDbContext>>();
+        await using var db = await dbFactory.CreateDbContextAsync();
+        var day = Day.Create(date);
+        db.Days.Add(day);
+        var category = db.Categories.First(c => c.Type == PointType.Sleep);
+        db.Points.Add(DataPoint.Create(day, category));
+        await db.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task CreateGridYear_PlacesMoodEmojiOnTheCorrectDay()
+    {
+        Services.GetService<AppDbSeeder>().SeedCategories();
+        await AddMoodPoint(new DateOnly(2024, 6, 10), "😀");
+
+        var gridYear = await Services.GetService<CalendarService>().CreateGridYear(2024);
+
+        gridYear.GridMonths[5].GridDays.Single(d => d.Date == new DateOnly(2024, 6, 10)).Emoji.Should().Be("😀");
+    }
+
+    [Fact]
+    public async Task CreateGridYear_ExcludesDeletedWrongYearAndNonMoodPoints()
+    {
+        Services.GetService<AppDbSeeder>().SeedCategories();
+        await AddMoodPoint(new DateOnly(2024, 6, 10), "😀");              // included
+        await AddMoodPoint(new DateOnly(2024, 6, 11), "😢", deleted: true); // excluded: deleted
+        await AddMoodPoint(new DateOnly(2023, 6, 10), "🙂");              // excluded: wrong year
+        await AddNonMoodPoint(new DateOnly(2024, 6, 12));                 // excluded: not the mood category
+
+        var gridYear = await Services.GetService<CalendarService>().CreateGridYear(2024);
+
+        var withEmoji = gridYear.GridMonths.SelectMany(m => m.GridDays).Where(d => d.Emoji != null).ToList();
+        withEmoji.Should().ContainSingle();
+        gridYear.GridMonths[5].GridDays.Single(d => d.Date == new DateOnly(2024, 6, 10)).Emoji.Should().Be("😀");
+    }
+
+    [Fact]
+    public async Task CreateGridYear_DoesNotThrow_OnDuplicateDates()
+    {
+        Services.GetService<AppDbSeeder>().SeedCategories();
+        // Two mood points on the same date is erroneous but must not crash the grid.
+        await AddMoodPoint(new DateOnly(2024, 6, 10), "😀");
+        await AddMoodPoint(new DateOnly(2024, 6, 10), "😢");
+
+        var calendarService = Services.GetService<CalendarService>();
+        var act = () => calendarService.CreateGridYear(2024);
+
+        var gridYear = (await act.Should().NotThrowAsync()).Subject;
+        gridYear.GridMonths[5].GridDays.Single(d => d.Date == new DateOnly(2024, 6, 10)).Emoji.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task CreateGridYear_ReturnsEmptyGrid_WhenMoodCategoryDisabled()
+    {
+        var dbFactory = Services.GetService<IDbContextFactory<AppDbContext>>();
+        Services.GetService<AppDbSeeder>().SeedCategories();
+        await AddMoodPoint(new DateOnly(2024, 6, 10), "😀");
+
+        // Disable the mood category before the service caches it on its first (and only) call.
+        await using (var db = await dbFactory.CreateDbContextAsync())
+        {
+            db.Categories.Single(c => c.Guid == MoodCategoryGuid).Enabled = false;
+            await db.SaveChangesAsync();
+        }
+
+        var gridYear = await Services.GetService<CalendarService>().CreateGridYear(2024);
+
+        gridYear.GridMonths.SelectMany(m => m.GridDays).Should().OnlyContain(d => d.Emoji == null);
+    }
+}

--- a/JournalApp.Tests/Data/CalendarServiceTests.cs
+++ b/JournalApp.Tests/Data/CalendarServiceTests.cs
@@ -3,9 +3,8 @@ using Microsoft.EntityFrameworkCore;
 namespace JournalApp.Tests.Data;
 
 /// <summary>
-/// CalendarService.CreateGridYear loads the year's mood points into a grid. Its compound filter
-/// (not deleted, right year, not in the future, mood category only) and its deliberate tolerance of
-/// duplicate dates are defensive logic that nothing else exercises.
+/// CalendarService.CreateGridYear loads the year's mood points into a grid.
+/// Its compound filter (not deleted, right year, not in the future, mood category only) and its deliberate tolerance of duplicate dates are defensive logic that nothing else exercises.
 /// </summary>
 public class CalendarServiceTests : JaTestContext
 {

--- a/JournalApp.Tests/Data/DataIntegrityTests.cs
+++ b/JournalApp.Tests/Data/DataIntegrityTests.cs
@@ -1,9 +1,11 @@
-﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
 
 namespace JournalApp.Tests.Data;
 
 /// <summary>
-/// Tests for data integrity, edge cases, and error handling in database operations.
+/// Tests for data integrity and edge cases in database operations that carry real app logic
+/// (index management, point generation, key/relationship invariants). Plain "does EF persist a
+/// nullable column" round-trips live in the backup round-trip tests instead.
 /// </summary>
 public class DataIntegrityTests : JaTestContext
 {
@@ -11,26 +13,6 @@ public class DataIntegrityTests : JaTestContext
     {
         await base.InitializeAsync();
         AddDbContext();
-    }
-
-    [Fact]
-    public async Task Day_DefaultDateValue_CanRoundTrip()
-    {
-        // Arrange
-        var dbFactory = Services.GetService<IDbContextFactory<AppDbContext>>();
-        using var db = await dbFactory.CreateDbContextAsync();
-
-        var day = new Day { Date = default };
-        db.Days.Add(day);
-        await db.SaveChangesAsync();
-
-        // Act
-        var savedGuid = day.Guid;
-        db.ChangeTracker.Clear();
-        var reloaded = await db.Days.SingleAsync(d => d.Guid == savedGuid);
-
-        // Assert
-        reloaded.Date.Should().Be(default);
     }
 
     [Fact]
@@ -105,7 +87,7 @@ public class DataIntegrityTests : JaTestContext
     public async Task Day_DuplicateDatesAllowed()
     {
         // Note: In practice, the app logic prevents duplicate dates,
-        // but the database schema doesn't enforce it
+        // but the database schema doesn't enforce it (CalendarService relies on tolerating them).
 
         // Arrange
         var dbFactory = Services.GetService<IDbContextFactory<AppDbContext>>();
@@ -121,6 +103,34 @@ public class DataIntegrityTests : JaTestContext
         // Act & Assert - Should not throw (no unique constraint on date)
         await db.SaveChangesAsync();
         db.Days.Count(d => d.Date == date).Should().Be(2);
+    }
+
+    [Fact]
+    public async Task DataPoint_PreservesExplicitGuidOnSave()
+    {
+        // Arrange
+        var dbFactory = Services.GetService<IDbContextFactory<AppDbContext>>();
+        var appDbSeeder = Services.GetService<AppDbSeeder>();
+        appDbSeeder.SeedCategories();
+
+        using var db = await dbFactory.CreateDbContextAsync();
+        var day = Day.Create(new DateOnly(2024, 1, 1));
+        db.Days.Add(day);
+
+        var category = db.Categories.First();
+        var point = DataPoint.Create(day, category);
+        var explicitGuid = Guid.NewGuid();
+        point.Guid = explicitGuid;
+
+        db.Points.Add(point);
+        await db.SaveChangesAsync();
+
+        // Act - reload from a cleared change tracker
+        db.ChangeTracker.Clear();
+        var reloaded = await db.Points.SingleAsync(p => p.Guid == explicitGuid);
+
+        // Assert - an explicitly assigned key is not regenerated
+        reloaded.Guid.Should().Be(explicitGuid);
     }
 
     [Fact]
@@ -240,81 +250,6 @@ public class DataIntegrityTests : JaTestContext
     }
 
     [Fact]
-    public async Task DataPoint_PreservesGuidOnSave()
-    {
-        // Arrange
-        var dbFactory = Services.GetService<IDbContextFactory<AppDbContext>>();
-        var appDbSeeder = Services.GetService<AppDbSeeder>();
-        appDbSeeder.SeedCategories();
-
-        using var db = await dbFactory.CreateDbContextAsync();
-        var day = Day.Create(new DateOnly(2024, 1, 1));
-        db.Days.Add(day);
-
-        var category = db.Categories.First();
-        var point = DataPoint.Create(day, category);
-        var originalGuid = point.Guid;
-
-        db.Points.Add(point);
-
-        // Act
-        await db.SaveChangesAsync();
-
-        // Assert - GUID should be preserved (may be auto-generated if not set)
-        point.Guid.Should().NotBe(Guid.Empty);
-        // If a GUID was set, it should be preserved, but DataPoint.Create may generate a new one
-        if (originalGuid != Guid.Empty)
-        {
-            point.Guid.Should().Be(originalGuid);
-        }
-    }
-
-    [Fact]
-    public async Task MedicationDose_CanBeNull()
-    {
-        // Arrange
-        var dbFactory = Services.GetService<IDbContextFactory<AppDbContext>>();
-        var appDbSeeder = Services.GetService<AppDbSeeder>();
-        appDbSeeder.SeedCategories();
-
-        using var db = await dbFactory.CreateDbContextAsync();
-        var day = Day.Create(new DateOnly(2024, 1, 1));
-        db.Days.Add(day);
-
-        var category = db.Categories.First(c => c.Type == PointType.Medication);
-        var point = DataPoint.Create(day, category);
-        point.MedicationDose = null;
-
-        db.Points.Add(point);
-
-        // Act & Assert - Should save successfully with null dose
-        await db.SaveChangesAsync();
-        point.MedicationDose.Should().BeNull();
-    }
-
-    [Fact]
-    public async Task Category_CanHaveNullMedicationEveryDaySince()
-    {
-        // Arrange
-        var dbFactory = Services.GetService<IDbContextFactory<AppDbContext>>();
-        using var db = await dbFactory.CreateDbContextAsync();
-
-        var category = new DataPointCategory
-        {
-            Name = "Test Med",
-            Group = "Medications",
-            Type = PointType.Medication,
-            MedicationEveryDaySince = null
-        };
-
-        db.AddCategory(category);
-
-        // Act & Assert - Should save successfully with null
-        await db.SaveChangesAsync();
-        category.MedicationEveryDaySince.Should().BeNull();
-    }
-
-    [Fact]
     public async Task GetOrCreateDayAndAddPoints_DoesNotDuplicatePoints()
     {
         // Test that calling GetOrCreateDayAndAddPoints multiple times
@@ -355,217 +290,6 @@ public class DataIntegrityTests : JaTestContext
     }
 
     [Fact]
-    public async Task DataPoint_HandlesNullText()
-    {
-        // Arrange
-        var dbFactory = Services.GetService<IDbContextFactory<AppDbContext>>();
-        var appDbSeeder = Services.GetService<AppDbSeeder>();
-        appDbSeeder.SeedCategories();
-
-        using var db = await dbFactory.CreateDbContextAsync();
-        var day = Day.Create(new DateOnly(2024, 1, 1));
-        db.Days.Add(day);
-
-        var category = db.Categories.First();
-        var point = DataPoint.Create(day, category);
-        point.Text = null;
-
-        db.Points.Add(point);
-
-        // Act & Assert - Should save successfully with null text
-        await db.SaveChangesAsync();
-        point.Text.Should().BeNull();
-    }
-
-    [Fact]
-    public async Task Day_HandlesFutureDate()
-    {
-        // Arrange
-        var dbFactory = Services.GetService<IDbContextFactory<AppDbContext>>();
-        using var db = await dbFactory.CreateDbContextAsync();
-
-        var futureDate = DateOnly.FromDateTime(DateTime.Now.AddYears(10));
-        var day = Day.Create(futureDate);
-
-        db.Days.Add(day);
-
-        // Act & Assert - Should save successfully
-        await db.SaveChangesAsync();
-        day.Date.Should().Be(futureDate);
-    }
-
-    [Fact]
-    public async Task Day_HandlesVeryOldDate()
-    {
-        // Arrange
-        var dbFactory = Services.GetService<IDbContextFactory<AppDbContext>>();
-        using var db = await dbFactory.CreateDbContextAsync();
-
-        var oldDate = new DateOnly(1900, 1, 1);
-        var day = Day.Create(oldDate);
-
-        db.Days.Add(day);
-
-        // Act & Assert - Should save successfully
-        await db.SaveChangesAsync();
-        day.Date.Should().Be(oldDate);
-    }
-
-    [Fact]
-    public async Task DataPoint_HandlesNullMood()
-    {
-        // Arrange
-        var dbFactory = Services.GetService<IDbContextFactory<AppDbContext>>();
-        var appDbSeeder = Services.GetService<AppDbSeeder>();
-        appDbSeeder.SeedCategories();
-
-        using var db = await dbFactory.CreateDbContextAsync();
-        var day = Day.Create(new DateOnly(2024, 1, 1));
-        db.Days.Add(day);
-
-        var category = db.Categories.First(c => c.Type == PointType.Mood);
-        var point = DataPoint.Create(day, category);
-        point.Mood = null;
-
-        db.Points.Add(point);
-
-        // Act & Assert
-        await db.SaveChangesAsync();
-        point.Mood.Should().BeNull();
-    }
-
-    [Fact]
-    public async Task DataPoint_HandlesBoundaryNumberValues()
-    {
-        // Arrange
-        var dbFactory = Services.GetService<IDbContextFactory<AppDbContext>>();
-        var appDbSeeder = Services.GetService<AppDbSeeder>();
-        appDbSeeder.SeedCategories();
-
-        using var db = await dbFactory.CreateDbContextAsync();
-        var day = Day.Create(new DateOnly(2024, 1, 1));
-        db.Days.Add(day);
-
-        var category = db.Categories.First(c => c.Type == PointType.Number);
-
-        // Test very large number
-        var point1 = DataPoint.Create(day, category);
-        point1.Number = double.MaxValue;
-        db.Points.Add(point1);
-
-        // Test very small number
-        var point2 = DataPoint.Create(day, category);
-        point2.Number = double.MinValue;
-        db.Points.Add(point2);
-
-        // Test zero
-        var point3 = DataPoint.Create(day, category);
-        point3.Number = 0;
-        db.Points.Add(point3);
-
-        // Test negative
-        var point4 = DataPoint.Create(day, category);
-        point4.Number = -999999.999;
-        db.Points.Add(point4);
-
-        // Act & Assert
-        await db.SaveChangesAsync();
-
-        point1.Number.Should().Be(double.MaxValue);
-        point2.Number.Should().Be(double.MinValue);
-        point3.Number.Should().Be(0);
-        point4.Number.Should().Be(-999999.999);
-    }
-
-    [Fact]
-    public async Task DataPoint_HandlesBoundaryDecimalValues()
-    {
-        // Arrange
-        var dbFactory = Services.GetService<IDbContextFactory<AppDbContext>>();
-        var appDbSeeder = Services.GetService<AppDbSeeder>();
-        appDbSeeder.SeedCategories();
-
-        using var db = await dbFactory.CreateDbContextAsync();
-        var day = Day.Create(new DateOnly(2024, 1, 1));
-        db.Days.Add(day);
-
-        var category = db.Categories.First(c => c.Type == PointType.Sleep);
-
-        // Test boundary values for sleep hours
-        var point1 = DataPoint.Create(day, category);
-        point1.SleepHours = 24m; // Max
-        db.Points.Add(point1);
-
-        var point2 = DataPoint.Create(day, category);
-        point2.SleepHours = 0m; // Min
-        db.Points.Add(point2);
-
-        var point3 = DataPoint.Create(day, category);
-        point3.SleepHours = 12.5m; // Typical
-        db.Points.Add(point3);
-
-        // Act & Assert
-        await db.SaveChangesAsync();
-
-        point1.SleepHours.Should().Be(24m);
-        point2.SleepHours.Should().Be(0m);
-        point3.SleepHours.Should().Be(12.5m);
-    }
-
-    [Fact]
-    public async Task Category_HandlesNullMedicationUnit()
-    {
-        // Arrange
-        var dbFactory = Services.GetService<IDbContextFactory<AppDbContext>>();
-        using var db = await dbFactory.CreateDbContextAsync();
-
-        var category = new DataPointCategory
-        {
-            Name = "Test Med",
-            Group = "Medications",
-            Type = PointType.Medication,
-            MedicationDose = 100m,
-            MedicationUnit = null
-        };
-
-        db.AddCategory(category);
-
-        // Act & Assert
-        await db.SaveChangesAsync();
-        category.MedicationUnit.Should().BeNull();
-    }
-
-    [Fact]
-    public async Task DataPoint_PreservesCreatedAtTimestamp()
-    {
-        // Arrange
-        var dbFactory = Services.GetService<IDbContextFactory<AppDbContext>>();
-        var appDbSeeder = Services.GetService<AppDbSeeder>();
-        appDbSeeder.SeedCategories();
-
-        using var db = await dbFactory.CreateDbContextAsync();
-        var day = Day.Create(new DateOnly(2024, 1, 1));
-        db.Days.Add(day);
-
-        var category = db.Categories.First();
-        var point = DataPoint.Create(day, category);
-        var originalTimestamp = point.CreatedAt;
-
-        db.Points.Add(point);
-        await db.SaveChangesAsync();
-
-        // Detach and reload
-        var pointGuid = point.Guid;
-        db.Entry(point).State = EntityState.Detached;
-
-        // Act
-        var reloadedPoint = await db.Points.FirstAsync(p => p.Guid == pointGuid);
-
-        // Assert - Timestamp should be preserved
-        reloadedPoint.CreatedAt.Should().BeCloseTo(originalTimestamp, TimeSpan.FromSeconds(1));
-    }
-
-    [Fact]
     public async Task GetOrCreateDayAndAddPoints_WithDisabledCategories_DoesNotCreatePoints()
     {
         // Arrange
@@ -596,32 +320,5 @@ public class DataIntegrityTests : JaTestContext
             day.Should().NotBeNull();
             day.Points.Should().BeEmpty();
         }
-    }
-
-    [Fact]
-    public async Task DataPoint_WithDeletedFlag_CanBeQueried()
-    {
-        // Arrange
-        var dbFactory = Services.GetService<IDbContextFactory<AppDbContext>>();
-        var appDbSeeder = Services.GetService<AppDbSeeder>();
-        appDbSeeder.SeedCategories();
-
-        using var db = await dbFactory.CreateDbContextAsync();
-        var day = Day.Create(new DateOnly(2024, 1, 1));
-        db.Days.Add(day);
-
-        var category = db.Categories.First();
-        var point = DataPoint.Create(day, category);
-        point.Deleted = true;
-
-        db.Points.Add(point);
-        await db.SaveChangesAsync();
-
-        // Act - Query deleted points
-        var deletedPoints = db.Points.Where(p => p.Deleted).ToList();
-
-        // Assert
-        deletedPoints.Should().HaveCount(1);
-        deletedPoints.First().Guid.Should().Be(point.Guid);
     }
 }

--- a/JournalApp.Tests/Data/DataIntegrityTests.cs
+++ b/JournalApp.Tests/Data/DataIntegrityTests.cs
@@ -3,9 +3,8 @@ using Microsoft.EntityFrameworkCore;
 namespace JournalApp.Tests.Data;
 
 /// <summary>
-/// Tests for data integrity and edge cases in database operations that carry real app logic
-/// (index management, point generation, key/relationship invariants). Plain "does EF persist a
-/// nullable column" round-trips live in the backup round-trip tests instead.
+/// Tests for data integrity and edge cases in database operations that carry real app logic (index management, point generation, key/relationship invariants).
+/// Plain "does EF persist a nullable column" round-trips live in the backup round-trip tests instead.
 /// </summary>
 public class DataIntegrityTests : JaTestContext
 {
@@ -86,8 +85,7 @@ public class DataIntegrityTests : JaTestContext
     [Fact]
     public async Task Day_DuplicateDatesAllowed()
     {
-        // Note: In practice, the app logic prevents duplicate dates,
-        // but the database schema doesn't enforce it (CalendarService relies on tolerating them).
+        // Note: In practice, the app logic prevents duplicate dates, but the database schema doesn't enforce it (CalendarService relies on tolerating them).
 
         // Arrange
         var dbFactory = Services.GetService<IDbContextFactory<AppDbContext>>();

--- a/JournalApp.Tests/Data/DataPointServiceTests.cs
+++ b/JournalApp.Tests/Data/DataPointServiceTests.cs
@@ -1,703 +1,201 @@
-﻿using JournalApp.Data;
+using JournalApp.Data;
 
 namespace JournalApp.Tests.Data;
 
 /// <summary>
-/// Tests for DataPointService class.
+/// Tests for DataPointService — the centralized layer for data point value manipulations.
+/// Each operation has at most one real branch (a 0/24 clamp, a 0-&gt;null conversion, a taken/not-taken
+/// reset) plus type/null guards, so the value cases are exercised as [Theory] rows.
 /// </summary>
 public class DataPointServiceTests
 {
     private readonly DataPointService _service = new();
 
+    private static DataPoint PointOfType(PointType type) =>
+        DataPoint.Create(Day.Create(new DateOnly(2024, 1, 1)), new DataPointCategory { Type = type });
 
-    [Fact]
-    public void DecrementSleep_DecreasesByHalfHour()
+    private static DataPoint SleepPoint(double? hours = null)
     {
-        // Arrange
-        var category = new DataPointCategory { Type = PointType.Sleep };
-        var day = Day.Create(new DateOnly(2024, 1, 1));
-        var point = DataPoint.Create(day, category);
-        point.SleepHours = 8.0m;
+        var point = PointOfType(PointType.Sleep);
+        point.SleepHours = (decimal?)hours;
+        return point;
+    }
 
-        // Act
+    private static DataPoint MedicationPoint(decimal? categoryDose) =>
+        DataPoint.Create(Day.Create(new DateOnly(2024, 1, 1)), new DataPointCategory { Type = PointType.Medication, MedicationDose = categoryDose });
+
+    [Theory]
+    [InlineData(8.0, 7.5)]
+    [InlineData(0.0, 0.0)]    // already at the floor
+    [InlineData(null, 0.0)]   // null is treated as 0
+    [InlineData(-5.0, 0.0)]   // never goes below zero
+    public void DecrementSleep_StepsDownByHalfHourAndClampsAtZero(double? start, double expected)
+    {
+        var point = SleepPoint(start);
+
         _service.DecrementSleep(point);
 
-        // Assert
-        point.SleepHours.Should().Be(7.5m);
+        point.SleepHours.Should().Be((decimal)expected);
     }
 
-    [Fact]
-    public void DecrementSleep_StopsAtZero()
+    [Theory]
+    [InlineData(8.0, 8.5)]
+    [InlineData(24.0, 24.0)]   // already at the ceiling
+    [InlineData(23.75, 24.0)]  // a half-hour step would overshoot, so it clamps
+    [InlineData(null, 0.5)]    // null is treated as 0
+    [InlineData(-5.0, -4.5)]   // increment has no lower clamp
+    public void IncrementSleep_StepsUpByHalfHourAndClampsAt24(double? start, double expected)
     {
-        // Arrange
-        var category = new DataPointCategory { Type = PointType.Sleep };
-        var day = Day.Create(new DateOnly(2024, 1, 1));
-        var point = DataPoint.Create(day, category);
-        point.SleepHours = 0.0m;
+        var point = SleepPoint(start);
 
-        // Act
-        _service.DecrementSleep(point);
-
-        // Assert
-        point.SleepHours.Should().Be(0.0m);
-    }
-
-    [Fact]
-    public void DecrementSleep_HandlesNull()
-    {
-        // Arrange
-        var category = new DataPointCategory { Type = PointType.Sleep };
-        var day = Day.Create(new DateOnly(2024, 1, 1));
-        var point = DataPoint.Create(day, category);
-        point.SleepHours = null;
-
-        // Act
-        _service.DecrementSleep(point);
-
-        // Assert
-        point.SleepHours.Should().Be(0.0m);
-    }
-
-    [Fact]
-    public void DecrementSleep_ThrowsException_WhenPointIsNull()
-    {
-        // Act & Assert
-        var act = () => _service.DecrementSleep(null!);
-        act.Should().Throw<ArgumentNullException>()
-            .WithParameterName("point");
-    }
-
-    [Fact]
-    public void DecrementSleep_ThrowsException_WhenNotSleepType()
-    {
-        // Arrange
-        var category = new DataPointCategory { Type = PointType.Mood };
-        var day = Day.Create(new DateOnly(2024, 1, 1));
-        var point = DataPoint.Create(day, category);
-
-        // Act & Assert
-        var act = () => _service.DecrementSleep(point);
-        act.Should().Throw<ArgumentException>()
-            .WithParameterName("point")
-            .WithMessage("DataPoint must be a sleep type.*");
-    }
-
-    [Fact]
-    public void IncrementSleep_IncreasesByHalfHour()
-    {
-        // Arrange
-        var category = new DataPointCategory { Type = PointType.Sleep };
-        var day = Day.Create(new DateOnly(2024, 1, 1));
-        var point = DataPoint.Create(day, category);
-        point.SleepHours = 8.0m;
-
-        // Act
         _service.IncrementSleep(point);
 
-        // Assert
-        point.SleepHours.Should().Be(8.5m);
+        point.SleepHours.Should().Be((decimal)expected);
     }
 
-    [Fact]
-    public void IncrementSleep_StopsAt24()
+    [Theory]
+    [InlineData("😀")]
+    [InlineData(null)]
+    [InlineData("")]
+    public void SetMood_StoresValue(string mood)
     {
-        // Arrange
-        var category = new DataPointCategory { Type = PointType.Sleep };
-        var day = Day.Create(new DateOnly(2024, 1, 1));
-        var point = DataPoint.Create(day, category);
-        point.SleepHours = 24.0m;
+        var point = PointOfType(PointType.Mood);
 
-        // Act
-        _service.IncrementSleep(point);
+        _service.SetMood(point, mood);
 
-        // Assert
-        point.SleepHours.Should().Be(24.0m);
+        point.Mood.Should().Be(mood);
     }
 
-    [Fact]
-    public void IncrementSleep_HandlesNull()
+    [Theory]
+    [InlineData(3, 3)]
+    [InlineData(0, null)]         // 0 represents "no rating"
+    [InlineData(-5, -5)]          // no range validation
+    [InlineData(999999, 999999)]
+    public void SetScaleIndex_StoresValueButConvertsZeroToNull(int value, int? expected)
     {
-        // Arrange
-        var category = new DataPointCategory { Type = PointType.Sleep };
-        var day = Day.Create(new DateOnly(2024, 1, 1));
-        var point = DataPoint.Create(day, category);
-        point.SleepHours = null;
+        var point = PointOfType(PointType.Scale);
 
-        // Act
-        _service.IncrementSleep(point);
+        _service.SetScaleIndex(point, value);
 
-        // Assert
-        point.SleepHours.Should().Be(0.5m);
+        point.ScaleIndex.Should().Be(expected);
     }
 
-    [Fact]
-    public void IncrementSleep_ThrowsException_WhenPointIsNull()
+    [Theory]
+    [InlineData(4, 4)]
+    [InlineData(null, 0)] // null represents "no rating"
+    public void GetScaleIndex_ReturnsValueOrZeroForNull(int? stored, int expected)
     {
-        // Act & Assert
-        var act = () => _service.IncrementSleep(null!);
-        act.Should().Throw<ArgumentNullException>()
-            .WithParameterName("point");
+        var point = PointOfType(PointType.Scale);
+        point.ScaleIndex = stored;
+
+        _service.GetScaleIndex(point).Should().Be(expected);
     }
 
-    [Fact]
-    public void IncrementSleep_ThrowsException_WhenNotSleepType()
+    [Theory]
+    [InlineData(false, 100.0, 100.0)] // not taken -> reset to category's default dose
+    [InlineData(null, 100.0, 100.0)]  // null also counts as not taken
+    [InlineData(false, null, null)]   // null category dose -> reset to null
+    [InlineData(false, 0.0, 0.0)]
+    [InlineData(false, -50.0, -50.0)] // category dose is copied verbatim, even if nonsensical
+    public void HandleMedicationTakenChanged_ResetsToCategoryDose_WhenNotTaken(bool? taken, double? categoryDose, double? expected)
     {
-        // Arrange
-        var category = new DataPointCategory { Type = PointType.Mood };
-        var day = Day.Create(new DateOnly(2024, 1, 1));
-        var point = DataPoint.Create(day, category);
+        var point = MedicationPoint((decimal?)categoryDose);
+        point.Bool = taken;
+        point.MedicationDose = 150m; // a custom dose that should be discarded
 
-        // Act & Assert
-        var act = () => _service.IncrementSleep(point);
-        act.Should().Throw<ArgumentException>()
-            .WithParameterName("point")
-            .WithMessage("DataPoint must be a sleep type.*");
-    }
-
-    [Fact]
-    public void SleepOperations_WorkTogether()
-    {
-        // Arrange
-        var category = new DataPointCategory { Type = PointType.Sleep };
-        var day = Day.Create(new DateOnly(2024, 1, 1));
-        var point = DataPoint.Create(day, category);
-        point.SleepHours = 8.0m;
-
-        // Act - Multiple operations
-        _service.IncrementSleep(point); // 8.5
-        _service.IncrementSleep(point); // 9.0
-        _service.DecrementSleep(point); // 8.5
-
-        // Assert
-        point.SleepHours.Should().Be(8.5m);
-    }
-
-
-
-    [Fact]
-    public void SetMood_UpdatesMoodValue()
-    {
-        // Arrange
-        var category = new DataPointCategory { Type = PointType.Mood };
-        var day = Day.Create(new DateOnly(2024, 1, 1));
-        var point = DataPoint.Create(day, category);
-
-        // Act
-        _service.SetMood(point, "😀");
-
-        // Assert
-        point.Mood.Should().Be("😀");
-    }
-
-    [Fact]
-    public void SetMood_AllowsNullValue()
-    {
-        // Arrange
-        var category = new DataPointCategory { Type = PointType.Mood };
-        var day = Day.Create(new DateOnly(2024, 1, 1));
-        var point = DataPoint.Create(day, category);
-        point.Mood = "😀";
-
-        // Act
-        _service.SetMood(point, null);
-
-        // Assert
-        point.Mood.Should().BeNull();
-    }
-
-    [Fact]
-    public void SetMood_ThrowsException_WhenPointIsNull()
-    {
-        // Act & Assert
-        var act = () => _service.SetMood(null!, "😀");
-        act.Should().Throw<ArgumentNullException>()
-            .WithParameterName("point");
-    }
-
-    [Fact]
-    public void SetMood_ThrowsException_WhenNotMoodType()
-    {
-        // Arrange
-        var category = new DataPointCategory { Type = PointType.Sleep };
-        var day = Day.Create(new DateOnly(2024, 1, 1));
-        var point = DataPoint.Create(day, category);
-
-        // Act & Assert
-        var act = () => _service.SetMood(point, "😀");
-        act.Should().Throw<ArgumentException>()
-            .WithParameterName("point")
-            .WithMessage("DataPoint must be a mood type.*");
-    }
-
-
-
-    [Fact]
-    public void SetScaleIndex_SetsValue()
-    {
-        // Arrange
-        var category = new DataPointCategory { Type = PointType.Scale };
-        var day = Day.Create(new DateOnly(2024, 1, 1));
-        var point = DataPoint.Create(day, category);
-
-        // Act
-        _service.SetScaleIndex(point, 3);
-
-        // Assert
-        point.ScaleIndex.Should().Be(3);
-    }
-
-    [Fact]
-    public void SetScaleIndex_ConvertsZeroToNull()
-    {
-        // Arrange
-        var category = new DataPointCategory { Type = PointType.Scale };
-        var day = Day.Create(new DateOnly(2024, 1, 1));
-        var point = DataPoint.Create(day, category);
-        point.ScaleIndex = 5;
-
-        // Act
-        _service.SetScaleIndex(point, 0);
-
-        // Assert
-        point.ScaleIndex.Should().BeNull();
-    }
-
-    [Fact]
-    public void SetScaleIndex_ThrowsException_WhenPointIsNull()
-    {
-        // Act & Assert
-        var act = () => _service.SetScaleIndex(null!, 3);
-        act.Should().Throw<ArgumentNullException>()
-            .WithParameterName("point");
-    }
-
-    [Fact]
-    public void SetScaleIndex_ThrowsException_WhenNotScaleType()
-    {
-        // Arrange
-        var category = new DataPointCategory { Type = PointType.Mood };
-        var day = Day.Create(new DateOnly(2024, 1, 1));
-        var point = DataPoint.Create(day, category);
-
-        // Act & Assert
-        var act = () => _service.SetScaleIndex(point, 3);
-        act.Should().Throw<ArgumentException>()
-            .WithParameterName("point")
-            .WithMessage("DataPoint must be a scale type.*");
-    }
-
-    [Fact]
-    public void GetScaleIndex_ReturnsValue()
-    {
-        // Arrange
-        var category = new DataPointCategory { Type = PointType.Scale };
-        var day = Day.Create(new DateOnly(2024, 1, 1));
-        var point = DataPoint.Create(day, category);
-        point.ScaleIndex = 4;
-
-        // Act
-        var result = _service.GetScaleIndex(point);
-
-        // Assert
-        result.Should().Be(4);
-    }
-
-    [Fact]
-    public void GetScaleIndex_ConvertsNullToZero()
-    {
-        // Arrange
-        var category = new DataPointCategory { Type = PointType.Scale };
-        var day = Day.Create(new DateOnly(2024, 1, 1));
-        var point = DataPoint.Create(day, category);
-        point.ScaleIndex = null;
-
-        // Act
-        var result = _service.GetScaleIndex(point);
-
-        // Assert
-        result.Should().Be(0);
-    }
-
-    [Fact]
-    public void GetScaleIndex_ThrowsException_WhenPointIsNull()
-    {
-        // Act & Assert
-        var act = () => _service.GetScaleIndex(null!);
-        act.Should().Throw<ArgumentNullException>()
-            .WithParameterName("point");
-    }
-
-    [Fact]
-    public void GetScaleIndex_ThrowsException_WhenNotScaleType()
-    {
-        // Arrange
-        var category = new DataPointCategory { Type = PointType.Mood };
-        var day = Day.Create(new DateOnly(2024, 1, 1));
-        var point = DataPoint.Create(day, category);
-
-        // Act & Assert
-        var act = () => _service.GetScaleIndex(point);
-        act.Should().Throw<ArgumentException>()
-            .WithParameterName("point")
-            .WithMessage("DataPoint must be a scale type.*");
-    }
-
-    [Fact]
-    public void ScaleOperations_WorkTogether()
-    {
-        // Arrange
-        var category = new DataPointCategory { Type = PointType.Scale };
-        var day = Day.Create(new DateOnly(2024, 1, 1));
-        var point = DataPoint.Create(day, category);
-
-        // Act - Set and get
-        _service.SetScaleIndex(point, 5);
-        var result1 = _service.GetScaleIndex(point);
-
-        _service.SetScaleIndex(point, 0);
-        var result2 = _service.GetScaleIndex(point);
-
-        // Assert
-        result1.Should().Be(5);
-        result2.Should().Be(0);
-        point.ScaleIndex.Should().BeNull();
-    }
-
-
-
-    [Fact]
-    public void HandleMedicationTakenChanged_ResetsDose_WhenNotTaken()
-    {
-        // Arrange
-        var category = new DataPointCategory
-        {
-            Type = PointType.Medication,
-            MedicationDose = 100m
-        };
-        var day = Day.Create(new DateOnly(2024, 1, 1));
-        var point = DataPoint.Create(day, category);
-        point.Bool = false;
-        point.MedicationDose = 150m; // Custom dose
-
-        // Act
         _service.HandleMedicationTakenChanged(point);
 
-        // Assert
-        point.MedicationDose.Should().Be(100m); // Reset to category default
+        point.MedicationDose.Should().Be((decimal?)expected);
     }
 
     [Fact]
-    public void HandleMedicationTakenChanged_ResetsDose_WhenNullNotTaken()
+    public void HandleMedicationTakenChanged_PreservesCustomDose_WhenTaken()
     {
-        // Arrange
-        var category = new DataPointCategory
-        {
-            Type = PointType.Medication,
-            MedicationDose = 100m
-        };
-        var day = Day.Create(new DateOnly(2024, 1, 1));
-        var point = DataPoint.Create(day, category);
-        point.Bool = null; // Not taken (null)
-        point.MedicationDose = 150m; // Custom dose
-
-        // Act
-        _service.HandleMedicationTakenChanged(point);
-
-        // Assert
-        point.MedicationDose.Should().Be(100m); // Reset to category default
-    }
-
-    [Fact]
-    public void HandleMedicationTakenChanged_PreservesDose_WhenTaken()
-    {
-        // Arrange
-        var category = new DataPointCategory
-        {
-            Type = PointType.Medication,
-            MedicationDose = 100m
-        };
-        var day = Day.Create(new DateOnly(2024, 1, 1));
-        var point = DataPoint.Create(day, category);
+        var point = MedicationPoint(100m);
         point.Bool = true;
-        point.MedicationDose = 150m; // Custom dose
+        point.MedicationDose = 150m;
 
-        // Act
         _service.HandleMedicationTakenChanged(point);
 
-        // Assert
-        point.MedicationDose.Should().Be(150m); // Preserve custom dose
+        point.MedicationDose.Should().Be(150m);
     }
 
     [Fact]
-    public void HandleMedicationTakenChanged_HandlesNullCategoryDose()
+    public void HandleMedicationTakenChanged_ToggleTwice_ResetsCustomDoseToDefault()
     {
-        // Arrange
-        var category = new DataPointCategory
-        {
-            Type = PointType.Medication,
-            MedicationDose = null // No default dose
-        };
-        var day = Day.Create(new DateOnly(2024, 1, 1));
-        var point = DataPoint.Create(day, category);
-        point.Bool = false;
-        point.MedicationDose = 150m; // Custom dose
+        // The "toggle the taken button twice to reset a custom dose" workflow.
+        var point = MedicationPoint(100m);
 
-        // Act
-        _service.HandleMedicationTakenChanged(point);
-
-        // Assert
-        point.MedicationDose.Should().BeNull(); // Reset to null
-    }
-
-    [Fact]
-    public void HandleMedicationTakenChanged_ThrowsException_WhenPointIsNull()
-    {
-        // Act & Assert
-        var act = () => _service.HandleMedicationTakenChanged(null!);
-        act.Should().Throw<ArgumentNullException>()
-            .WithParameterName("point");
-    }
-
-    [Fact]
-    public void HandleMedicationTakenChanged_ThrowsException_WhenNotMedicationType()
-    {
-        // Arrange
-        var category = new DataPointCategory
-        {
-            Type = PointType.Bool // Not a medication
-        };
-        var day = Day.Create(new DateOnly(2024, 1, 1));
-        var point = DataPoint.Create(day, category);
-
-        // Act & Assert
-        var act = () => _service.HandleMedicationTakenChanged(point);
-        act.Should().Throw<ArgumentException>()
-            .WithParameterName("point")
-            .WithMessage("DataPoint must be a medication type.*");
-    }
-
-    [Fact]
-    public void HandleMedicationTakenChanged_AllowsToggleTwiceToResetDose()
-    {
-        // This test demonstrates the "toggle twice to reset" feature mentioned in the comment
-
-        // Arrange
-        var category = new DataPointCategory
-        {
-            Type = PointType.Medication,
-            MedicationDose = 100m
-        };
-        var day = Day.Create(new DateOnly(2024, 1, 1));
-        var point = DataPoint.Create(day, category);
-
-        // User takes medication with custom dose
         point.Bool = true;
         point.MedicationDose = 150m;
         _service.HandleMedicationTakenChanged(point);
-        point.MedicationDose.Should().Be(150m); // Keeps custom dose
+        point.MedicationDose.Should().Be(150m); // taken keeps the custom dose
 
-        // User toggles to "not taken"
         point.Bool = false;
         _service.HandleMedicationTakenChanged(point);
-        point.MedicationDose.Should().Be(100m); // Resets to default
+        point.MedicationDose.Should().Be(100m); // not taken resets to default
 
-        // User toggles back to "taken"
         point.Bool = true;
         _service.HandleMedicationTakenChanged(point);
-        point.MedicationDose.Should().Be(100m); // Now has default dose again
+        point.MedicationDose.Should().Be(100m); // stays at the default
     }
 
-
-
-    [Fact]
-    public void IncrementSleep_WithNegativeValue_CorrectsBehavior()
+    public static TheoryData<Action<DataPointService>> NullPointOperations() => new()
     {
-        // Arrange
-        var category = new DataPointCategory { Type = PointType.Sleep };
-        var day = Day.Create(new DateOnly(2024, 1, 1));
-        var point = DataPoint.Create(day, category);
-        point.SleepHours = -5m; // Invalid negative value
+        service => service.DecrementSleep(null!),
+        service => service.IncrementSleep(null!),
+        service => service.SetMood(null!, "😀"),
+        service => service.SetScaleIndex(null!, 3),
+        service => service.GetScaleIndex(null!),
+        service => service.HandleMedicationTakenChanged(null!),
+    };
 
-        // Act
-        _service.IncrementSleep(point);
-
-        // Assert - Should increment from -5 to -4.5
-        // The service doesn't validate negative values, just applies increment
-        point.SleepHours.Should().Be(-4.5m);
-    }
-
-    [Fact]
-    public void DecrementSleep_WithNegativeValue_StopsAtZero()
+    [Theory]
+    [MemberData(nameof(NullPointOperations))]
+    public void Operations_ThrowArgumentNullException_WhenPointIsNull(Action<DataPointService> operation)
     {
-        // Arrange
-        var category = new DataPointCategory { Type = PointType.Sleep };
-        var day = Day.Create(new DateOnly(2024, 1, 1));
-        var point = DataPoint.Create(day, category);
-        point.SleepHours = -5m;
+        var act = () => operation(_service);
 
-        // Act
-        _service.DecrementSleep(point);
-
-        // Assert - Math.Max ensures it doesn't go more negative
-        point.SleepHours.Should().Be(0m);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("point");
     }
 
     [Fact]
-    public void IncrementSleep_BeyondMaximum_StopsAt24()
+    public void SleepOperations_ThrowArgumentException_WhenNotSleepType()
     {
-        // Arrange
-        var category = new DataPointCategory { Type = PointType.Sleep };
-        var day = Day.Create(new DateOnly(2024, 1, 1));
-        var point = DataPoint.Create(day, category);
-        point.SleepHours = 23.75m;
+        var point = PointOfType(PointType.Mood);
 
-        // Act - Try to increment multiple times
-        _service.IncrementSleep(point); // 24.0
-        _service.IncrementSleep(point); // Should stay 24.0
-        _service.IncrementSleep(point); // Should stay 24.0
-
-        // Assert
-        point.SleepHours.Should().Be(24.0m);
+        ((Action)(() => _service.DecrementSleep(point))).Should().Throw<ArgumentException>()
+            .WithParameterName("point").WithMessage("DataPoint must be a sleep type.*");
+        ((Action)(() => _service.IncrementSleep(point))).Should().Throw<ArgumentException>()
+            .WithParameterName("point").WithMessage("DataPoint must be a sleep type.*");
     }
 
     [Fact]
-    public void SetMood_WithEmptyString_AcceptsValue()
+    public void SetMood_ThrowsArgumentException_WhenNotMoodType()
     {
-        // Arrange
-        var category = new DataPointCategory { Type = PointType.Mood };
-        var day = Day.Create(new DateOnly(2024, 1, 1));
-        var point = DataPoint.Create(day, category);
+        var point = PointOfType(PointType.Sleep);
 
-        // Act
-        _service.SetMood(point, string.Empty);
-
-        // Assert
-        point.Mood.Should().Be(string.Empty);
+        ((Action)(() => _service.SetMood(point, "😀"))).Should().Throw<ArgumentException>()
+            .WithParameterName("point").WithMessage("DataPoint must be a mood type.*");
     }
 
     [Fact]
-    public void SetMood_WithVeryLongString_AcceptsValue()
+    public void ScaleOperations_ThrowArgumentException_WhenNotScaleType()
     {
-        // Arrange
-        var category = new DataPointCategory { Type = PointType.Mood };
-        var day = Day.Create(new DateOnly(2024, 1, 1));
-        var point = DataPoint.Create(day, category);
-        var longMood = string.Concat(Enumerable.Repeat("😀", 100));
+        var point = PointOfType(PointType.Mood);
 
-        // Act
-        _service.SetMood(point, longMood);
-
-        // Assert
-        point.Mood.Should().Be(longMood);
+        ((Action)(() => _service.SetScaleIndex(point, 3))).Should().Throw<ArgumentException>()
+            .WithParameterName("point").WithMessage("DataPoint must be a scale type.*");
+        ((Action)(() => _service.GetScaleIndex(point))).Should().Throw<ArgumentException>()
+            .WithParameterName("point").WithMessage("DataPoint must be a scale type.*");
     }
 
     [Fact]
-    public void SetScaleIndex_WithNegativeValue_AcceptsValue()
+    public void HandleMedicationTakenChanged_ThrowsArgumentException_WhenNotMedicationType()
     {
-        // Arrange
-        var category = new DataPointCategory { Type = PointType.Scale };
-        var day = Day.Create(new DateOnly(2024, 1, 1));
-        var point = DataPoint.Create(day, category);
+        var point = PointOfType(PointType.Bool);
 
-        // Act
-        _service.SetScaleIndex(point, -5);
-
-        // Assert - Service doesn't validate range, just stores the value
-        point.ScaleIndex.Should().Be(-5);
+        ((Action)(() => _service.HandleMedicationTakenChanged(point))).Should().Throw<ArgumentException>()
+            .WithParameterName("point").WithMessage("DataPoint must be a medication type.*");
     }
-
-    [Fact]
-    public void SetScaleIndex_WithVeryLargeValue_AcceptsValue()
-    {
-        // Arrange
-        var category = new DataPointCategory { Type = PointType.Scale };
-        var day = Day.Create(new DateOnly(2024, 1, 1));
-        var point = DataPoint.Create(day, category);
-
-        // Act
-        _service.SetScaleIndex(point, 999999);
-
-        // Assert
-        point.ScaleIndex.Should().Be(999999);
-    }
-
-    [Fact]
-    public void HandleMedicationTakenChanged_WithZeroDose_HandlesCorrectly()
-    {
-        // Arrange
-        var category = new DataPointCategory
-        {
-            Type = PointType.Medication,
-            MedicationDose = 0m
-        };
-        var day = Day.Create(new DateOnly(2024, 1, 1));
-        var point = DataPoint.Create(day, category);
-        point.Bool = false;
-        point.MedicationDose = 100m;
-
-        // Act
-        _service.HandleMedicationTakenChanged(point);
-
-        // Assert - Should reset to category's zero dose
-        point.MedicationDose.Should().Be(0m);
-    }
-
-    [Fact]
-    public void HandleMedicationTakenChanged_WithNegativeDose_HandlesCorrectly()
-    {
-        // Arrange
-        var category = new DataPointCategory
-        {
-            Type = PointType.Medication,
-            MedicationDose = -50m // Invalid but testing behavior
-        };
-        var day = Day.Create(new DateOnly(2024, 1, 1));
-        var point = DataPoint.Create(day, category);
-        point.Bool = false;
-        point.MedicationDose = 100m;
-
-        // Act
-        _service.HandleMedicationTakenChanged(point);
-
-        // Assert - Should reset to category's dose, even if negative
-        point.MedicationDose.Should().Be(-50m);
-    }
-
-    [Fact]
-    public void GetScaleIndex_MultipleCallsSamePoint_ReturnsConsistentValue()
-    {
-        // Arrange
-        var category = new DataPointCategory { Type = PointType.Scale };
-        var day = Day.Create(new DateOnly(2024, 1, 1));
-        var point = DataPoint.Create(day, category);
-        point.ScaleIndex = 5;
-
-        // Act
-        var result1 = _service.GetScaleIndex(point);
-        var result2 = _service.GetScaleIndex(point);
-        var result3 = _service.GetScaleIndex(point);
-
-        // Assert
-        result1.Should().Be(5);
-        result2.Should().Be(5);
-        result3.Should().Be(5);
-    }
-
-    [Fact]
-    public void SleepOperations_WithDecimalPrecision_MaintainPrecision()
-    {
-        // Arrange
-        var category = new DataPointCategory { Type = PointType.Sleep };
-        var day = Day.Create(new DateOnly(2024, 1, 1));
-        var point = DataPoint.Create(day, category);
-        point.SleepHours = 7.75m;
-
-        // Act
-        _service.IncrementSleep(point); // 8.25
-        _service.DecrementSleep(point); // 7.75
-
-        // Assert - Should maintain decimal precision
-        point.SleepHours.Should().Be(7.75m);
-    }
-
 }

--- a/JournalApp.Tests/Data/DataPointServiceTests.cs
+++ b/JournalApp.Tests/Data/DataPointServiceTests.cs
@@ -4,8 +4,7 @@ namespace JournalApp.Tests.Data;
 
 /// <summary>
 /// Tests for DataPointService — the centralized layer for data point value manipulations.
-/// Each operation has at most one real branch (a 0/24 clamp, a 0-&gt;null conversion, a taken/not-taken
-/// reset) plus type/null guards, so the value cases are exercised as [Theory] rows.
+/// Each operation has at most one real branch (a 0/24 clamp, a 0->null conversion, a taken/not-taken reset) plus type/null guards, so the value cases are exercised as [Theory] rows.
 /// </summary>
 public class DataPointServiceTests
 {

--- a/JournalApp.Tests/Data/ModelTests.cs
+++ b/JournalApp.Tests/Data/ModelTests.cs
@@ -1,0 +1,51 @@
+namespace JournalApp.Tests.Data;
+
+/// <summary>
+/// Pure formatting/predicate logic on the data models that feeds layout and validation.
+/// </summary>
+public class ModelTests
+{
+    [Theory]
+    [InlineData("Medications", "Vitamin D", 3, "Medications | Vitamin D #3")]
+    [InlineData("Medications", null, 0, "Medications #0")]
+    [InlineData("Medications", "", 0, "Medications #0")]
+    [InlineData(null, "Overall mood", 1, "Overall mood #1")]
+    [InlineData(null, null, 5, " #5")]
+    public void DataPointCategory_ToString_FormatsByGroupAndNamePresence(string group, string name, int index, string expected)
+    {
+        new DataPointCategory { Group = group, Name = name, Index = index }.ToString().Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(PointType.Mood, true)]
+    [InlineData(PointType.Sleep, true)]
+    [InlineData(PointType.Scale, true)]
+    [InlineData(PointType.Number, true)]
+    [InlineData(PointType.LowToHigh, false)]
+    [InlineData(PointType.MildToSevere, false)]
+    [InlineData(PointType.Bool, false)]
+    [InlineData(PointType.Text, false)]
+    [InlineData(PointType.Note, false)]
+    [InlineData(PointType.Medication, false)]
+    [InlineData(PointType.None, false)]
+    public void DataPointCategory_SingleLine_TrueOnlyForMoodSleepScaleNumber(PointType type, bool expected)
+    {
+        new DataPointCategory { Type = type }.SingleLine.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("Notes", true)]
+    [InlineData("Medications", false)]
+    [InlineData("notes", false)] // case-sensitive
+    public void DataPoint_IsTimestampedNote_TrueOnlyForNotesGroup(string group, bool expected)
+    {
+        var point = DataPoint.Create(Day.Create(new DateOnly(2024, 1, 1)), new DataPointCategory { Group = group });
+        point.IsTimestampedNote.Should().Be(expected);
+    }
+
+    [Fact]
+    public void DataPoint_IsTimestampedNote_False_WhenCategoryNull()
+    {
+        new DataPoint().IsTimestampedNote.Should().BeFalse();
+    }
+}

--- a/JournalApp.Tests/Data/PreferenceServiceTests.cs
+++ b/JournalApp.Tests/Data/PreferenceServiceTests.cs
@@ -73,4 +73,51 @@ public class PreferenceServiceTests : JaTestContext
         preferences.Get<string>("safety_plan", "fallback").Should().BeNull();
         preferenceService.SafetyPlan.Should().BeNull();
     }
+
+    [Fact]
+    public void SelectedAppTheme_WithValidStoredValue_ParsesIt()
+    {
+        // Arrange - store the value before the service reads (and caches) it.
+        var preferences = Services.GetService<IPreferences>();
+        preferences.Set("theme", AppTheme.Dark.ToString());
+
+        var preferenceService = Services.GetService<PreferenceService>();
+
+        // Act & Assert
+        preferenceService.SelectedAppTheme.Should().Be(AppTheme.Dark);
+    }
+
+    [Fact]
+    public void LastExportDate_WithValidStoredValue_ReturnsStoredValue()
+    {
+        // Arrange
+        var preferences = Services.GetService<IPreferences>();
+        var stored = new DateTimeOffset(2024, 3, 15, 10, 0, 0, TimeSpan.Zero);
+        preferences.Set("last_export", stored.ToString("O"));
+
+        var preferenceService = Services.GetService<PreferenceService>();
+
+        // Act & Assert - a valid stored date is returned as-is, not reset to now.
+        preferenceService.LastExportDate.Should().Be(stored);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("not-a-mood")]
+    [InlineData("🤔")] // present in DataPoint.Moods but excluded from the generated palette
+    public void GetMoodColor_ReturnsTransparent_ForEmptyUnknownOrExcludedEmoji(string emoji)
+    {
+        var preferenceService = Services.GetService<PreferenceService>();
+
+        preferenceService.GetMoodColor(emoji).Should().Be("transparent");
+    }
+
+    [Fact]
+    public void GetMoodColor_ReturnsHexColor_ForKnownMood()
+    {
+        var preferenceService = Services.GetService<PreferenceService>();
+
+        preferenceService.GetMoodColor("🤩").Should().StartWith("#");
+    }
 }

--- a/JournalApp.Tests/DateUtilTests.cs
+++ b/JournalApp.Tests/DateUtilTests.cs
@@ -13,6 +13,23 @@ public class DateUtilTests
     }
 
     [Fact]
+    public void DatesTo_ReturnsSingleDate_WhenStartEqualsEnd()
+    {
+        var date = new DateOnly(2023, 09, 1);
+
+        date.DatesTo(date).Should().ContainSingle().Which.Should().Be(date);
+    }
+
+    [Fact]
+    public void DatesTo_ReturnsEmpty_WhenStartAfterEnd()
+    {
+        var start = new DateOnly(2023, 09, 4);
+        var end = new DateOnly(2023, 09, 1);
+
+        start.DatesTo(end).Should().BeEmpty();
+    }
+
+    [Fact]
     public void NextTest()
     {
         var originalDate = new DateOnly(2023, 01, 01);

--- a/JournalApp.Tests/ImportExportTests.cs
+++ b/JournalApp.Tests/ImportExportTests.cs
@@ -92,79 +92,41 @@ public class ImportExportTests : JaTestContext
     }
 
     [Fact]
-    public async Task ReadArchive_ThrowsOnInvalidZip()
-    {
-        // Arrange
-        var invalidZipPath = Path.Combine(Path.GetTempPath(), $"invalid-{Guid.NewGuid()}.journalapp");
-        await File.WriteAllTextAsync(invalidZipPath, "This is not a valid zip file");
-
-        try
-        {
-            // Act & Assert
-            var act = async () => await BackupFile.ReadArchive(invalidZipPath);
-            await act.Should().ThrowAsync<InvalidDataException>();
-        }
-        finally
-        {
-            if (File.Exists(invalidZipPath))
-                File.Delete(invalidZipPath);
-        }
-    }
+    public Task ReadArchive_ThrowsOnInvalidZip() =>
+        AssertReadArchiveThrows<InvalidDataException>(
+            stream => stream.WriteAsync(System.Text.Encoding.UTF8.GetBytes("This is not a valid zip file")).AsTask());
 
     [Fact]
-    public async Task ReadArchive_ThrowsOnMissingInternalFile()
-    {
-        // Arrange - Create a valid ZIP without the required internal file
-        var zipPath = Path.Combine(Path.GetTempPath(), $"empty-{Guid.NewGuid()}.journalapp");
-
-        try
-        {
-            using (var stream = File.Create(zipPath))
-            using (var archive = new System.IO.Compression.ZipArchive(stream, System.IO.Compression.ZipArchiveMode.Create))
-            {
-                // Create an entry with wrong name
-                var entry = archive.CreateEntry("wrong-name.json");
-                using var entryStream = entry.Open();
-                await entryStream.WriteAsync(System.Text.Encoding.UTF8.GetBytes("{}"));
-            }
-
-            // Act & Assert
-            var act = async () => await BackupFile.ReadArchive(zipPath);
-            await act.Should().ThrowAsync<InvalidOperationException>()
-                .WithMessage("No valid backup found!*");
-        }
-        finally
-        {
-            if (File.Exists(zipPath))
-                File.Delete(zipPath);
-        }
-    }
+    public Task ReadArchive_ThrowsOnMissingInternalFile() =>
+        AssertReadArchiveThrows<InvalidOperationException>(
+            stream => WriteZipEntry(stream, "wrong-name.json", "{}"),
+            expectedMessage: "No valid backup found!*");
 
     [Fact]
-    public async Task ReadArchive_ThrowsOnCorruptedJSON()
+    public Task ReadArchive_ThrowsOnCorruptedJSON() =>
+        AssertReadArchiveThrows<System.Text.Json.JsonException>(
+            stream => WriteZipEntry(stream, "journalapp-data.json", "{invalid json content"));
+
+    private static async Task AssertReadArchiveThrows<TException>(Func<Stream, Task> writeContents, string expectedMessage = null)
+        where TException : Exception
     {
-        // Arrange - Create a valid ZIP with corrupted JSON
-        var zipPath = Path.Combine(Path.GetTempPath(), $"corrupted-{Guid.NewGuid()}.journalapp");
+        using var stream = new MemoryStream();
+        await writeContents(stream);
+        stream.Position = 0;
 
-        try
-        {
-            using (var stream = File.Create(zipPath))
-            using (var archive = new System.IO.Compression.ZipArchive(stream, System.IO.Compression.ZipArchiveMode.Create))
-            {
-                var entry = archive.CreateEntry("journalapp-data.json");
-                using var entryStream = entry.Open();
-                await entryStream.WriteAsync(System.Text.Encoding.UTF8.GetBytes("{invalid json content"));
-            }
+        var act = async () => await BackupFile.ReadArchive(stream);
+        var assertion = await act.Should().ThrowAsync<TException>();
 
-            // Act & Assert
-            var act = async () => await BackupFile.ReadArchive(zipPath);
-            await act.Should().ThrowAsync<System.Text.Json.JsonException>();
-        }
-        finally
-        {
-            if (File.Exists(zipPath))
-                File.Delete(zipPath);
-        }
+        if (expectedMessage != null)
+            assertion.WithMessage(expectedMessage);
+    }
+
+    private static async Task WriteZipEntry(Stream stream, string entryName, string content)
+    {
+        using var archive = new System.IO.Compression.ZipArchive(stream, System.IO.Compression.ZipArchiveMode.Create, leaveOpen: true);
+        var entry = archive.CreateEntry(entryName);
+        using var entryStream = entry.Open();
+        await entryStream.WriteAsync(System.Text.Encoding.UTF8.GetBytes(content));
     }
 
     [Fact]

--- a/JournalApp.Tests/KeyEventServiceTests.cs
+++ b/JournalApp.Tests/KeyEventServiceTests.cs
@@ -3,9 +3,8 @@ using Microsoft.Extensions.Logging.Abstractions;
 namespace JournalApp.Tests;
 
 /// <summary>
-/// KeyEventService is the Android back-button action stack. Its peek-not-pop behaviour and the
-/// empty-stack guard are the only things preventing the user from being trapped in a dialog or
-/// unable to background the app, yet nothing else exercises them.
+/// KeyEventService is the Android back-button action stack.
+/// Its peek-not-pop behaviour and the empty-stack guard are the only things preventing the user from being trapped in a dialog or unable to background the app, yet nothing else exercises them.
 /// </summary>
 public class KeyEventServiceTests
 {

--- a/JournalApp.Tests/KeyEventServiceTests.cs
+++ b/JournalApp.Tests/KeyEventServiceTests.cs
@@ -1,0 +1,87 @@
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace JournalApp.Tests;
+
+/// <summary>
+/// KeyEventService is the Android back-button action stack. Its peek-not-pop behaviour and the
+/// empty-stack guard are the only things preventing the user from being trapped in a dialog or
+/// unable to background the app, yet nothing else exercises them.
+/// </summary>
+public class KeyEventServiceTests
+{
+    private static KeyEventService NewService() => new(NullLogger<KeyEventService>.Instance);
+
+    [Fact]
+    public void Exited_OnEmptyStack_DoesNotThrowOrUnderflow()
+    {
+        var service = NewService();
+
+        var act = () => service.Exited();
+
+        act.Should().NotThrow();
+        service.CurrentDepth.Should().Be(0);
+    }
+
+    [Fact]
+    public void EnteredAndExited_TrackDepthAsLifo()
+    {
+        var service = NewService();
+
+        service.Entered(() => { });
+        service.Entered(() => { });
+        service.CurrentDepth.Should().Be(2);
+
+        service.Exited();
+        service.CurrentDepth.Should().Be(1);
+    }
+
+    [Fact]
+    public void ResetStack_ClearsAllActions()
+    {
+        var service = NewService();
+        service.Entered(() => { });
+        service.Entered(() => { });
+
+        service.ResetStack();
+
+        service.CurrentDepth.Should().Be(0);
+    }
+
+    [Fact]
+    public void OnBackButtonPressed_InvokesOnlyTopActionAndReturnsTrue()
+    {
+        var service = NewService();
+        var firstInvoked = false;
+        var secondInvoked = false;
+        service.Entered(() => firstInvoked = true);
+        service.Entered(() => secondInvoked = true);
+
+        var handled = service.OnBackButtonPressed();
+
+        handled.Should().BeTrue();
+        secondInvoked.Should().BeTrue();
+        firstInvoked.Should().BeFalse();
+    }
+
+    [Fact]
+    public void OnBackButtonPressed_DoesNotPopTheAction()
+    {
+        var service = NewService();
+        var count = 0;
+        service.Entered(() => count++);
+
+        service.OnBackButtonPressed();
+        service.OnBackButtonPressed();
+
+        count.Should().Be(2);
+        service.CurrentDepth.Should().Be(1);
+    }
+
+    [Fact]
+    public void OnBackButtonPressed_ReturnsFalse_WhenStackEmpty()
+    {
+        var service = NewService();
+
+        service.OnBackButtonPressed().Should().BeFalse();
+    }
+}

--- a/JournalApp.Tests/MarkupUtilTests.cs
+++ b/JournalApp.Tests/MarkupUtilTests.cs
@@ -7,6 +7,8 @@ public class MarkupUtilTests
     [InlineData("Hello World", "hello-world")]
     [InlineData("Hello World!", "hello-world")]
     [InlineData("Hello & World", "hello-world")]
+    [InlineData("!Hello", "hello")] // leading invalid char is trimmed
+    [InlineData("!@#$", "")]        // all-invalid collapses to one dash then trims to empty
     public void ToClassName(string actual, string expected)
     {
         MarkupUtil.ToClassName(actual).Should().Be(expected);

--- a/JournalApp.Tests/Pages/Calendar/GridMonthTests.cs
+++ b/JournalApp.Tests/Pages/Calendar/GridMonthTests.cs
@@ -1,0 +1,63 @@
+using System.Globalization;
+
+namespace JournalApp.Tests;
+
+/// <summary>
+/// GridMonth lays out a month as up-to-six week rows. The leading-blank offset formula
+/// (GridMonth.cs) is the app's real calendar math and is only touched indirectly today.
+/// Cultures are cloned with an explicit FirstDayOfWeek so the tests don't depend on host ICU data.
+/// </summary>
+public class GridMonthTests
+{
+    private static CultureInfo CultureStartingOn(DayOfWeek firstDay)
+    {
+        var culture = (CultureInfo)CultureInfo.InvariantCulture.Clone();
+        culture.DateTimeFormat.FirstDayOfWeek = firstDay;
+        return culture;
+    }
+
+    [Theory]
+    [InlineData(DayOfWeek.Sunday, 1)] // 1 Jan 2024 is a Monday, so a Sunday-first week has one leading blank.
+    [InlineData(DayOfWeek.Monday, 0)] // A Monday-first week starts the month in the first cell.
+    public void GridDays_PlaceFirstOfMonthAfterCorrectLeadingBlanks(DayOfWeek firstDayOfWeek, int expectedBlanks)
+    {
+        var month = new GridMonth(2024, 1, CultureStartingOn(firstDayOfWeek), new());
+
+        month.GridDays.TakeWhile(d => d.Date == null).Should().HaveCount(expectedBlanks);
+        month.GridDays.First(d => d.Date != null).Date.Should().Be(new DateOnly(2024, 1, 1));
+    }
+
+    [Fact]
+    public void GridDays_ContainEveryDayOfTheMonth()
+    {
+        // February 2024 is a leap February with 29 days.
+        var month = new GridMonth(2024, 2, CultureStartingOn(DayOfWeek.Sunday), new());
+
+        var realDates = month.GridDays.Where(d => d.Date != null).Select(d => d.Date!.Value).ToList();
+        realDates.Should().HaveCount(29).And.OnlyHaveUniqueItems();
+        realDates.Min().Should().Be(new DateOnly(2024, 2, 1));
+        realDates.Max().Should().Be(new DateOnly(2024, 2, 29));
+    }
+
+    [Fact]
+    public void GridDay_CarriesMoodEmoji_ForMatchingDate()
+    {
+        var date = new DateOnly(2024, 1, 15);
+        var moodPoints = new Dictionary<DateOnly, DataPoint> { [date] = new() { Mood = "😀" } };
+
+        var month = new GridMonth(2024, 1, CultureStartingOn(DayOfWeek.Sunday), moodPoints);
+
+        month.GridDays.Single(d => d.Date == date).Emoji.Should().Be("😀");
+        month.GridDays.Where(d => d.Date != null && d.Date != date).Should().OnlyContain(d => d.Emoji == null);
+    }
+
+    [Fact]
+    public void DaysOfWeek_StartWithCultureFirstDay()
+    {
+        var month = new GridMonth(2024, 1, CultureStartingOn(DayOfWeek.Monday), new());
+
+        month.DaysOfWeek.Should().HaveCount(7);
+        month.DaysOfWeek.First().Should().Be(DayOfWeek.Monday);
+        month.DaysOfWeek.Last().Should().Be(DayOfWeek.Sunday);
+    }
+}

--- a/JournalApp.Tests/Pages/Calendar/GridMonthTests.cs
+++ b/JournalApp.Tests/Pages/Calendar/GridMonthTests.cs
@@ -3,8 +3,8 @@ using System.Globalization;
 namespace JournalApp.Tests;
 
 /// <summary>
-/// GridMonth lays out a month as up-to-six week rows. The leading-blank offset formula
-/// (GridMonth.cs) is the app's real calendar math and is only touched indirectly today.
+/// GridMonth lays out a month as up-to-six week rows.
+/// The leading-blank offset formula (GridMonth.cs) is the app's real calendar math and is only touched indirectly today.
 /// Cultures are cloned with an explicit FirstDayOfWeek so the tests don't depend on host ICU data.
 /// </summary>
 public class GridMonthTests

--- a/JournalApp.Tests/Pages/Trends/TrendChartPointTests.cs
+++ b/JournalApp.Tests/Pages/Trends/TrendChartPointTests.cs
@@ -2,9 +2,7 @@ namespace JournalApp.Tests;
 
 /// <summary>
 /// TrendChartPoint maps a DataPoint onto the numeric values plotted on the trends charts.
-/// The mood mapping is the highest-risk piece: ChartEmojis is a hand-maintained list whose order
-/// is intentionally reversed relative to <see cref="DataPoint.Moods"/> and drops the "🤔" entry,
-/// with nothing linking the two at compile time.
+/// The mood mapping is the highest-risk piece: ChartEmojis is a hand-maintained list whose order is intentionally reversed relative to <see cref="DataPoint.Moods"/> and drops the "🤔" entry, with nothing linking the two at compile time.
 /// </summary>
 public class TrendChartPointTests
 {

--- a/JournalApp.Tests/Pages/Trends/TrendChartPointTests.cs
+++ b/JournalApp.Tests/Pages/Trends/TrendChartPointTests.cs
@@ -1,0 +1,122 @@
+namespace JournalApp.Tests;
+
+/// <summary>
+/// TrendChartPoint maps a DataPoint onto the numeric values plotted on the trends charts.
+/// The mood mapping is the highest-risk piece: ChartEmojis is a hand-maintained list whose order
+/// is intentionally reversed relative to <see cref="DataPoint.Moods"/> and drops the "🤔" entry,
+/// with nothing linking the two at compile time.
+/// </summary>
+public class TrendChartPointTests
+{
+    private static DataPoint MoodPoint(string mood)
+    {
+        var point = DataPoint.Create(Day.Create(new DateOnly(2024, 1, 1)), new DataPointCategory { Type = PointType.Mood });
+        point.Mood = mood;
+        return point;
+    }
+
+    private static DataPoint MedPoint(bool? taken, decimal? dose, decimal? categoryDose, string categoryUnit)
+    {
+        var category = new DataPointCategory { Type = PointType.Medication, MedicationDose = categoryDose, MedicationUnit = categoryUnit };
+        var point = DataPoint.Create(Day.Create(new DateOnly(2024, 1, 1)), category);
+        point.Bool = taken;
+        point.MedicationDose = dose;
+        return point;
+    }
+
+    [Theory]
+    [InlineData("😭", 1)]
+    [InlineData("😢", 2)]
+    [InlineData("😕", 3)]
+    [InlineData("😐", 4)]
+    [InlineData("🙂", 5)]
+    [InlineData("😀", 6)]
+    [InlineData("🤩", 7)]
+    public void Mood_MapsEachChartEmojiToOneBasedIndex(string emoji, int expected)
+    {
+        new TrendChartPoint(new DateOnly(2024, 1, 1), MoodPoint(emoji)).Mood.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("🤔")] // deliberately excluded from the chart scale
+    [InlineData("")]
+    [InlineData("not-an-emoji")]
+    public void Mood_ReturnsNull_ForThinkingUnmappedOrEmpty(string mood)
+    {
+        new TrendChartPoint(new DateOnly(2024, 1, 1), MoodPoint(mood)).Mood.Should().BeNull();
+    }
+
+    [Fact]
+    public void Mood_ReturnsNull_WhenPointIsNull()
+    {
+        new TrendChartPoint(new DateOnly(2024, 1, 1), null).Mood.Should().BeNull();
+    }
+
+    [Fact]
+    public void MedDose_ReturnsPointDose_WhenTakenAndCategoryHasDose()
+    {
+        new TrendChartPoint(new DateOnly(2024, 1, 1), MedPoint(taken: true, dose: 150m, categoryDose: 100m, categoryUnit: null))
+            .MedDose.Should().Be(150m);
+    }
+
+    [Fact]
+    public void MedDose_ReturnsPointDose_WhenTakenAndCategoryHasUnitButNoDose()
+    {
+        new TrendChartPoint(new DateOnly(2024, 1, 1), MedPoint(taken: true, dose: 50m, categoryDose: null, categoryUnit: "mg"))
+            .MedDose.Should().Be(50m);
+    }
+
+    [Fact]
+    public void MedDose_ReturnsOne_WhenTakenButCategoryHasNoDoseOrUnit()
+    {
+        // A plain "taken/not taken" medication with no dose or unit charts as a flat 1.
+        new TrendChartPoint(new DateOnly(2024, 1, 1), MedPoint(taken: true, dose: 999m, categoryDose: null, categoryUnit: null))
+            .MedDose.Should().Be(1m);
+    }
+
+    [Fact]
+    public void MedDose_ReturnsZero_WhenNotTaken()
+    {
+        new TrendChartPoint(new DateOnly(2024, 1, 1), MedPoint(taken: false, dose: 100m, categoryDose: 100m, categoryUnit: "mg"))
+            .MedDose.Should().Be(0m);
+    }
+
+    [Fact]
+    public void MedDose_ReturnsNull_WhenTakenIsNull()
+    {
+        new TrendChartPoint(new DateOnly(2024, 1, 1), MedPoint(taken: null, dose: 100m, categoryDose: 100m, categoryUnit: "mg"))
+            .MedDose.Should().BeNull();
+    }
+
+    [Fact]
+    public void Bool_MapsTakenStateToOneZeroOrNull()
+    {
+        var day = Day.Create(new DateOnly(2024, 1, 1));
+        var category = new DataPointCategory { Type = PointType.Bool };
+
+        DataPoint WithBool(bool? value)
+        {
+            var p = DataPoint.Create(day, category);
+            p.Bool = value;
+            return p;
+        }
+
+        new TrendChartPoint(new DateOnly(2024, 1, 1), WithBool(true)).Bool.Should().Be(1m);
+        new TrendChartPoint(new DateOnly(2024, 1, 1), WithBool(false)).Bool.Should().Be(0m);
+        new TrendChartPoint(new DateOnly(2024, 1, 1), WithBool(null)).Bool.Should().BeNull();
+    }
+
+    [Fact]
+    public void PassthroughValues_ReflectUnderlyingPoint()
+    {
+        var point = DataPoint.Create(Day.Create(new DateOnly(2024, 1, 1)), new DataPointCategory { Type = PointType.Sleep });
+        point.SleepHours = 7.5m;
+        point.ScaleIndex = 3;
+        point.Number = 42d;
+
+        var tcp = new TrendChartPoint(new DateOnly(2024, 1, 1), point);
+        tcp.SleepHours.Should().Be(7.5m);
+        tcp.Scale.Should().Be(3m);
+        tcp.Number.Should().Be(42m);
+    }
+}

--- a/JournalApp.Tests/Utilities/ColorUtilTests.cs
+++ b/JournalApp.Tests/Utilities/ColorUtilTests.cs
@@ -1,0 +1,56 @@
+using Color = Microsoft.Maui.Graphics.Color;
+
+namespace JournalApp.Tests;
+
+/// <summary>
+/// ColorUtil supplies the channel-wise gradient math that builds the mood palette.
+/// A naive refactor of either method (dropping the hue wraparound, or lerping the wrong channels)
+/// would silently shift every mood colour.
+/// </summary>
+public class ColorUtilTests
+{
+    private static readonly Color Red = new(1f, 0f, 0f);
+    private static readonly Color Blue = new(0f, 0f, 1f);
+
+    [Fact]
+    public void GetGradientColor_AtZero_ReturnsStart()
+    {
+        var result = ColorUtil.GetGradientColor(Red, Blue, 0f);
+        result.Red.Should().BeApproximately(1f, 0.001f);
+        result.Green.Should().BeApproximately(0f, 0.001f);
+        result.Blue.Should().BeApproximately(0f, 0.001f);
+    }
+
+    [Fact]
+    public void GetGradientColor_AtOne_ReturnsEnd()
+    {
+        var result = ColorUtil.GetGradientColor(Red, Blue, 1f);
+        result.Red.Should().BeApproximately(0f, 0.001f);
+        result.Green.Should().BeApproximately(0f, 0.001f);
+        result.Blue.Should().BeApproximately(1f, 0.001f);
+    }
+
+    [Fact]
+    public void GetGradientColor_AtHalf_InterpolatesEachChannel()
+    {
+        var result = ColorUtil.GetGradientColor(Red, Blue, 0.5f);
+        result.Red.Should().BeApproximately(0.5f, 0.001f);
+        result.Green.Should().BeApproximately(0f, 0.001f);
+        result.Blue.Should().BeApproximately(0.5f, 0.001f);
+    }
+
+    [Fact]
+    public void GetComplementary_ShiftsHueByHalf()
+    {
+        var complementary = Red.GetComplementary(); // hue 0 -> 0.5
+        complementary.GetHue().Should().BeApproximately(0.5f, 0.01f);
+    }
+
+    [Fact]
+    public void GetComplementary_WrapsHueAroundOne()
+    {
+        var start = Red.WithHue(0.75f);
+        var complementary = start.GetComplementary(); // 0.75 + 0.5 = 1.25 -> 0.25
+        complementary.GetHue().Should().BeApproximately(0.25f, 0.01f);
+    }
+}

--- a/JournalApp.Tests/Utilities/ColorUtilTests.cs
+++ b/JournalApp.Tests/Utilities/ColorUtilTests.cs
@@ -4,8 +4,7 @@ namespace JournalApp.Tests;
 
 /// <summary>
 /// ColorUtil supplies the channel-wise gradient math that builds the mood palette.
-/// A naive refactor of either method (dropping the hue wraparound, or lerping the wrong channels)
-/// would silently shift every mood colour.
+/// A naive refactor of either method (dropping the hue wraparound, or lerping the wrong channels) would silently shift every mood colour.
 /// </summary>
 public class ColorUtilTests
 {

--- a/JournalApp/Properties/AssemblyInfo.cs
+++ b/JournalApp/Properties/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+using System.Runtime.CompilerServices;
+
+// Allows the test project to exercise internal logic (e.g. TrendChartPoint, KeyEventService.OnBackButtonPressed)
+// that has no public surface but carries real regression risk.
+[assembly: InternalsVisibleTo("JournalApp.Tests")]

--- a/JournalApp/Properties/AssemblyInfo.cs
+++ b/JournalApp/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 using System.Runtime.CompilerServices;
 
-// Allows the test project to exercise internal logic (e.g. TrendChartPoint, KeyEventService.OnBackButtonPressed)
-// that has no public surface but carries real regression risk.
+// Allows the test project to exercise internal logic (e.g. TrendChartPoint, KeyEventService.OnBackButtonPressed) that has no public surface but carries real regression risk.
 [assembly: InternalsVisibleTo("JournalApp.Tests")]


### PR DESCRIPTION
A full pass over `JournalApp.Tests` aimed at a **stronger** suite, not a higher test count. The suite ends up with fewer test methods and ~350 fewer lines of test code, yet covers more real behavior and has **zero skipped tests**.

## Results
| | Before | After |
|---|---|---|
| Test methods | 135 | 127 |
| Runtime cases | 189 (1 skipped) | 238 (0 skipped) |
| Test code | 3,766 lines | 3,410 lines |

All 238 pass locally.

## Removed weak tests
- **12 framework-not-app tests** in `DataIntegrityTests` that only verified EF/SQLite round-trips a nullable/typed column (null string/decimal, boundary doubles, `DateOnly`, a bool predicate) with no app logic in the path — already covered by the backup round-trip tests.
- **2 tautological tests** in `DataPointServiceTests`.
- The phantom `[Fact(Skip)]` `ReplaceDbSets_IsAtomic_RollsBackOnError` stub — rollback is genuinely tested by `ReplaceDbSets_WithPartialFailure_RollsBackCompletely`.

## Consolidated (~30 near-duplicate `[Fact]`s → `[Theory]` blocks)
`DataPointServiceTests` (703 → ~215 lines), `AppDbContextTests`, `AppDataServiceTests`, and `ImportExportTests` (shared `MemoryStream` helper). Every meaningful assertion is retained; the medication-boundary test is now deterministic instead of `DateTime.Now`-based.

## Reworked
- `DataPoint_PreservesGuidOnSave` had a **dead conditional** (`DataPoint.Create` never sets a Guid, so the branch never ran) — now asserts an explicit key survives the round-trip.
- Tightened `AddCategory` index assertion from `>0` to the exact value.

## Added branch coverage for previously-dark logic
Enabled by `[assembly: InternalsVisibleTo("JournalApp.Tests")]`:
- **`TrendChartPoint`** mood/med-dose mapping — guards the `ChartEmojis` list against silently diverging from `DataPoint.Moods` (they're maintained by hand with nothing linking them, so a reorder corrupts every mood chart).
- **`GridMonth`** calendar leading-blank offset math across first-day-of-week cultures.
- **`CalendarService`** point filtering and deliberate duplicate-date tolerance.
- **`KeyEventService`** back-button stack (peek-not-pop, empty-stack underflow guard).
- **`ColorUtil`** gradient/complementary math, model formatting/predicates, `PreferenceService` success branches, and the import-wizard warning / success / read-failure branches.

## Deliberately not added (to avoid fluff)
- An export "user cancels save" test — while writing it I found `FileSaverResult(null, null)` is treated as success, so the wizard's "cancelled" `else` branch is unreachable dead code and a real cancel already surfaces as an exception the existing failure test covers.
- `JaMessageBox` bUnit tests — the tri-state result mapping is already exercised at the service layer via `TestDialogService`, and these MudBlazor-overlay component tests are brittle.

## Verification
`global.json` pins SDK `10.0.200` (dev machine has `10.0.301`), so I ran the suite with a temporary `rollForward` adjustment and reverted it — the only non-test change is the `InternalsVisibleTo` assembly attribute.