### PR TITLE
Add scroll-under app bars, M3 dialog conformance, and motion polish

### DIFF
--- a/JournalApp/Components/EditCategoryDialog.razor
+++ b/JournalApp/Components/EditCategoryDialog.razor
@@ -57,7 +57,7 @@
 
         <MudButton Class="cancel-button" StartIcon="@Icons.Material.Rounded.Close" OnClick="Cancel">Cancel</MudButton>
 
-        <MudButton Class="submit-button" StartIcon="@Icons.Material.Rounded.Check" OnClick="Submit" Variant="Variant.Filled" Color="Color.Primary">Submit</MudButton>
+        <MudButton Class="submit-button" StartIcon="@Icons.Material.Rounded.Check" OnClick="Submit" Color="Color.Primary">Submit</MudButton>
     </DialogActions>
 </MudDialog>
 

--- a/JournalApp/Components/EditDoseDialog.razor
+++ b/JournalApp/Components/EditDoseDialog.razor
@@ -26,7 +26,7 @@
     <DialogActions>
         <MudButton Class="cancel-button" StartIcon="@Icons.Material.Rounded.Close" OnClick="Cancel">Cancel</MudButton>
 
-        <MudButton Class="submit-button" StartIcon="@Icons.Material.Rounded.Check" OnClick="Submit" Variant="Variant.Filled" Color="Color.Primary">Submit</MudButton>
+        <MudButton Class="submit-button" StartIcon="@Icons.Material.Rounded.Check" OnClick="Submit" Color="Color.Primary">Submit</MudButton>
     </DialogActions>
 </MudDialog>
 

--- a/JournalApp/Components/EditNoteDialog.razor
+++ b/JournalApp/Components/EditNoteDialog.razor
@@ -15,7 +15,7 @@
     <DialogActions>
         <MudButton Class="cancel-button" StartIcon="@Icons.Material.Rounded.Close" OnClick="Cancel">Cancel</MudButton>
 
-        <MudButton Class="submit-button" StartIcon="@Icons.Material.Rounded.Check" OnClick="Submit" Variant="Variant.Filled" Color="Color.Primary">Submit</MudButton>
+        <MudButton Class="submit-button" StartIcon="@Icons.Material.Rounded.Check" OnClick="Submit" Color="Color.Primary">Submit</MudButton>
     </DialogActions>
 </MudDialog>
 

--- a/JournalApp/Components/JaMessageBox.razor
+++ b/JournalApp/Components/JaMessageBox.razor
@@ -61,7 +61,7 @@
                 }
                 else if (!string.IsNullOrWhiteSpace(YesText))
                 {
-                    <MudButton Class="mud-message-box__yes-button" OnClick="OnYesClicked" Variant="Variant.Filled" Color="Color.Primary">@YesText</MudButton>
+                    <MudButton Class="mud-message-box__yes-button" OnClick="OnYesClicked" Color="Color.Primary">@YesText</MudButton>
                 }
             </MudFocusTrap>
         </div>

--- a/JournalApp/wwwroot/app.css
+++ b/JournalApp/wwwroot/app.css
@@ -36,6 +36,17 @@ body {
   border-radius: 999px;
   margin: 0 8px;
   background-color: var(--mud-palette-surface);
+  transition: background-color 200ms cubic-bezier(0.2, 0, 0, 1);
+}
+
+/* M3 scroll-under: the header lifts to surfaceContainer tones once content scrolls beneath it (body.ja-scrolled comes from index.html). */
+body.ja-scrolled .page-header,
+body.ja-scrolled .page-toolbar {
+  background-color: var(--mud-palette-surface);
+}
+
+body.ja-scrolled .switcher {
+  background-color: var(--mud-palette-gray-lighter);
 }
 
 .switcher-header {
@@ -57,6 +68,7 @@ body {
   background-color: var(--mud-palette-background);
   color: var(--mud-palette-text-primary);
   --mud-palette-action-default: var(--mud-palette-text-secondary);
+  transition: background-color 200ms cubic-bezier(0.2, 0, 0, 1);
 }
 
 /* M3 top app bar title is title-large: 22px regular, not a bold h6. */
@@ -81,6 +93,7 @@ body {
   position: sticky !important;
   background-color: var(--mud-palette-background);
   color: var(--mud-palette-text-primary);
+  transition: background-color 200ms cubic-bezier(0.2, 0, 0, 1);
 }
 
 .page-body {
@@ -89,17 +102,23 @@ body {
   margin: 0 auto !important;
   padding: 8px !important;
   padding-bottom: 15vh !important;
-  animation: fadeInUp 0.15s ease-out;
+  animation: fadeInUp 0.3s cubic-bezier(0.05, 0.7, 0.1, 1);
 }
 
 @keyframes fadeInUp {
   from {
     opacity: 0;
-    transform: translateY(8px);
+    transform: translateY(12px);
   }
   to {
     opacity: 1;
     transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .page-body {
+    animation: none;
   }
 }
 
@@ -221,7 +240,16 @@ body {
   font-size: inherit;
 }
 
-.mud-dialog-title, .mud-card-header {
+/* M3 dialogs lead with a left-aligned headline; card headers stay centered. */
+.mud-dialog-title {
+  padding: 0 !important;
+  padding-top: 8px !important;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+}
+
+.mud-card-header {
   padding: 0 !important;
   padding-top: 8px !important;
   display: flex;
@@ -293,6 +321,12 @@ body {
   background-color: var(--mud-palette-surface);
   border-radius: 6px;
   padding: 14px 16px;
+  transition: transform 120ms cubic-bezier(0.2, 0, 0, 1);
+}
+
+/* M3E press feedback: rows give a gentle squish, like the calendar cells already do. */
+.main-timeline .data-point-container:active {
+  transform: scale(0.98);
 }
 
 .main-timeline .data-point-container:first-child {

--- a/JournalApp/wwwroot/index.html
+++ b/JournalApp/wwwroot/index.html
@@ -41,6 +41,13 @@
             var elementTop = document.querySelector(descendantSelector).offsetTop - document.querySelector(ancestorSelector).offsetTop;
             document.scrollingElement.scrollTo({ top: elementTop, behavior: scrollBehavior });
         }
+
+        // Drives the M3 scroll-under app bar state: app.css tints the sticky header when content has scrolled beneath it.
+        (function () {
+            const update = () => document.body.classList.toggle('ja-scrolled', (document.scrollingElement.scrollTop || 0) > 4);
+            addEventListener('scroll', update, { passive: true });
+            update();
+        })();
     </script>
 
 </body>


### PR DESCRIPTION
Slice (a) of the MD3 Expressive pass, following #97 and #98: motion and chrome behavior:

- **Scroll-under app bars.** The sticky header (toolbar + day switcher) lifts to surfaceContainer tones once content scrolls beneath it and settles back at the top, matching the standard M3 scroll-under cue. Driven by a passive scroll listener in index.html that toggles a `ja-scrolled` body class; the tint transitions over 200ms.
- **M3 basic dialog conformance.** Dialog headlines are left-aligned (card headers stay centered), and the confirming action is a text button instead of a filled pill across EditNoteDialog, EditDoseDialog, EditCategoryDialog, and JaMessageBox.
- **Motion polish.** Page entry animates with the M3 emphasized-decelerate curve (300ms, 12px rise) instead of a 150ms ease-out, with a `prefers-reduced-motion` opt-out. Grouped list rows get the same gentle press squish the calendar cells already had.