### PR TITLE
Modernize Settings selection controls to Material 3

### DIFF
--- a/JournalApp/Pages/ManageCategoriesPage.razor
+++ b/JournalApp/Pages/ManageCategoriesPage.razor
@@ -24,7 +24,7 @@
     }
     else
     {
-        <MudPaper>
+        <div class="manage-list">
             @foreach (var c in Categories.OrderBy(c => c.Index))
             {
                 <div id="@($"manage-category-{c.Guid}")" class="manage-category">
@@ -39,7 +39,7 @@
                                Color="Color.Primary" aria-label="Show in home" />
                 </div>
             }
-        </MudPaper>
+        </div>
     }
 </main>
 

--- a/JournalApp/Pages/ManageCategoriesPage.razor.css
+++ b/JournalApp/Pages/ManageCategoriesPage.razor.css
@@ -1,8 +1,28 @@
+/* M3E grouped list, like the home timeline: every category is its own tonal row, and the first and last rows carry the large group radius. */
+.manage-list {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
 .manage-category {
   display: flex;
   flex-direction: row;
   align-items: center;
   gap: 4px;
+  background-color: var(--mud-palette-surface);
+  border-radius: 6px;
+  padding: 6px 14px 6px 6px;
+}
+
+.manage-category:first-child {
+  border-top-left-radius: 18px;
+  border-top-right-radius: 18px;
+}
+
+.manage-category:last-child {
+  border-bottom-left-radius: 18px;
+  border-bottom-right-radius: 18px;
 }
 
 ::deep .manage-category-edit-button {
@@ -15,8 +35,4 @@
 
 ::deep .manage-category-enabled-switch {
   margin-right: -2px;
-}
-
-::deep .mud-paper {
-  padding: 12px;
 }

--- a/JournalApp/Pages/SettingsPage.razor
+++ b/JournalApp/Pages/SettingsPage.razor
@@ -28,79 +28,100 @@ else
             <section>
                 <MudText Class="list-group-title">Personalization</MudText>
 
-                <MudPaper Class="settings-group">
-                    <MudToggleGroup T="AppTheme" Value="PreferenceService.SelectedAppTheme" ValueChanged="v => PreferenceService.SelectedAppTheme = v" SelectionMode="SelectionMode.SingleSelection" Size="Size.Small" CheckMark aria-label="Theme for entire app">
-                        <MudToggleItem T="AppTheme" Value="@(AppTheme.Light)">Light</MudToggleItem>
-                        <MudToggleItem T="AppTheme" Value="@(AppTheme.Dark)">Dark</MudToggleItem>
-                        <MudToggleItem T="AppTheme" Value="@(AppTheme.Unspecified)">System</MudToggleItem>
-                    </MudToggleGroup>
+                <div class="settings-group">
+                    <div class="settings-item">
+                        <MudText Class="settings-item-title">Theme</MudText>
 
-                    <MudSwitch @bind-Value="PreferenceService.HideNotes" Color="Color.Primary" aria-label="Hide the notes section on the home page">Hide "Today's notes"</MudSwitch>
-                </MudPaper>
+                        <MudToggleGroup T="AppTheme" Value="PreferenceService.SelectedAppTheme" ValueChanged="v => PreferenceService.SelectedAppTheme = v" SelectionMode="SelectionMode.SingleSelection" Size="Size.Small" CheckMark aria-label="Theme for entire app">
+                            <MudToggleItem T="AppTheme" Value="@(AppTheme.Light)">Light</MudToggleItem>
+                            <MudToggleItem T="AppTheme" Value="@(AppTheme.Dark)">Dark</MudToggleItem>
+                            <MudToggleItem T="AppTheme" Value="@(AppTheme.Unspecified)">System</MudToggleItem>
+                        </MudToggleGroup>
+                    </div>
+
+                    <div class="settings-item">
+                        <MudSwitch @bind-Value="PreferenceService.HideNotes" Color="Color.Primary" aria-label="Hide the notes section on the home page">Hide "Today's notes"</MudSwitch>
+                    </div>
+                </div>
             </section>
 
             <section>
                 <MudText Class="list-group-title">Data & backups</MudText>
 
-                <MudPaper Class="settings-group">
-                    @if ((DateTimeOffset.Now - PreferenceService.LastExportDate) > TimeSpan.FromDays(180))
-                    {
-                        <MudAlert Severity="Severity.Info">
-                            It's been a while since your last backup. Consider exporting your data to keep it safe.
-                        </MudAlert>
-                    }
+                <div class="settings-group">
+                    <div class="settings-item">
+                        @if ((DateTimeOffset.Now - PreferenceService.LastExportDate) > TimeSpan.FromDays(180))
+                        {
+                            <MudAlert Severity="Severity.Info">
+                                It's been a while since your last backup. Consider exporting your data to keep it safe.
+                            </MudAlert>
+                        }
 
-                    <MudText Typo="Typo.body2">Last backup: @(PreferenceService.LastExportDate.ToString("d"))</MudText>
+                        <MudText Typo="Typo.body2">Last backup: @(PreferenceService.LastExportDate.ToString("d"))</MudText>
 
-                    <MudButtonGroup Variant="Variant.Outlined" FullWidth>
-                        <MudButton StartIcon="@Icons.Material.Rounded.Upload" OnClick="StartExport">Export data</MudButton>
+                        <MudButtonGroup Variant="Variant.Outlined" FullWidth>
+                            <MudButton StartIcon="@Icons.Material.Rounded.Upload" OnClick="StartExport">Export data</MudButton>
 
-                        <MudButton StartIcon="@Icons.Material.Rounded.Download" OnClick="PickAndStartImport">Import data</MudButton>
-                    </MudButtonGroup>
-                </MudPaper>
+                            <MudButton StartIcon="@Icons.Material.Rounded.Download" OnClick="PickAndStartImport">Import data</MudButton>
+                        </MudButtonGroup>
+                    </div>
+                </div>
             </section>
 
             <section>
                 <MudText Class="list-group-title">Safety</MudText>
 
-                <MudPaper Class="settings-group">
-                    <MudText Typo="Typo.body2">
-                        Your coping strategies and sources of support that can be used in a crisis.
-                    </MudText>
+                <div class="settings-group">
+                    <div class="settings-item">
+                        <MudText Typo="Typo.body2">
+                            Your coping strategies and sources of support that can be used in a crisis.
+                        </MudText>
 
-                    <MudButton StartIcon="@Icons.Material.Rounded.HealthAndSafety" OnClick="SetUpSafetyPlan" Variant="Variant.Outlined" FullWidth>
-                        Set up Safety Plan
-                    </MudButton>
-                </MudPaper>
+                        <MudButton StartIcon="@Icons.Material.Rounded.HealthAndSafety" OnClick="SetUpSafetyPlan" Variant="Variant.Outlined" FullWidth>
+                            Set up Safety Plan
+                        </MudButton>
+                    </div>
+                </div>
             </section>
 
             <section>
                 <MudText Class="list-group-title">About</MudText>
 
-                <MudPaper Class="settings-group">
-                    <MudCopyText Text="@($"Journal App {ThisAssembly.AssemblyInformationalVersion}")" />
-                    <MudCopyText Text="@($"{DeviceInfo.Current.Platform} {DeviceInfo.Current.VersionString}")" />
-
-                    <MudLink Href="https://github.com/danielchalmers/JournalApp/issues" StartIcon="@Icons.Material.Rounded.Feedback">Submit feedback</MudLink>
-                    <MudLink Href="https://play.google.com/store/apps/details?id=com.danielchalmers.journalapp" StartIcon="@Icons.Material.Rounded.Shop">View on Play Store</MudLink>
-                    <MudLink Href="https://github.com/danielchalmers/JournalApp" StartIcon="@Icons.Material.Rounded.Code">View source code</MudLink>
-                </MudPaper>
+                <div class="settings-group">
+                    <div class="settings-item">
+                        <MudCopyText Text="@($"Journal App {ThisAssembly.AssemblyInformationalVersion}")" />
+                    </div>
+                    <div class="settings-item">
+                        <MudCopyText Text="@($"{DeviceInfo.Current.Platform} {DeviceInfo.Current.VersionString}")" />
+                    </div>
+                    <div class="settings-item">
+                        <MudLink Href="https://github.com/danielchalmers/JournalApp/issues" StartIcon="@Icons.Material.Rounded.Feedback">Submit feedback</MudLink>
+                    </div>
+                    <div class="settings-item">
+                        <MudLink Href="https://play.google.com/store/apps/details?id=com.danielchalmers.journalapp" StartIcon="@Icons.Material.Rounded.Shop">View on Play Store</MudLink>
+                    </div>
+                    <div class="settings-item">
+                        <MudLink Href="https://github.com/danielchalmers/JournalApp" StartIcon="@Icons.Material.Rounded.Code">View source code</MudLink>
+                    </div>
+                </div>
             </section>
 
             <section>
                 <MudText Class="list-group-title">Credits</MudText>
 
-                <MudPaper Class="settings-group">
-                    <MudTextField T="string" Text="@CreditsText" Typo="Typo.body2" ReadOnly Underline="false"
-                                  Sizing="InputSizing.Auto" MaxLines="_creditsExpanded ? 0 : 10" FullWidth />
+                <div class="settings-group">
+                    <div class="settings-item">
+                        <MudTextField T="string" Text="@CreditsText" Typo="Typo.body2" ReadOnly Underline="false"
+                                      Sizing="InputSizing.Auto" MaxLines="_creditsExpanded ? 0 : 10" FullWidth />
 
-                    @if (!_creditsExpanded)
-                    {
-                        <MudLink OnClick="() => _creditsExpanded = true" StartIcon="@Icons.Material.Rounded.ExpandMore">
-                            Expand credits
-                        </MudLink>
-                    }
-                </MudPaper>
+                        @if (!_creditsExpanded)
+                        {
+                            <MudLink OnClick="() => _creditsExpanded = true" StartIcon="@Icons.Material.Rounded.ExpandMore">
+                                Expand credits
+                            </MudLink>
+                        }
+                    </div>
+                </div>
             </section>
         </div>
     </main>

--- a/JournalApp/Pages/SettingsPage.razor
+++ b/JournalApp/Pages/SettingsPage.razor
@@ -29,13 +29,13 @@ else
                 <MudText Class="list-group-title">Personalization</MudText>
 
                 <MudPaper Class="settings-group">
-                    <MudRadioGroup T="AppTheme" Value="PreferenceService.SelectedAppTheme" ValueChanged="v => PreferenceService.SelectedAppTheme = v" aria-label="Theme for entire app">
-                        <MudRadio Value="@(AppTheme.Light)">Light</MudRadio>
-                        <MudRadio Value="@(AppTheme.Dark)">Dark</MudRadio>
-                        <MudRadio Value="@(AppTheme.Unspecified)">System</MudRadio>
-                    </MudRadioGroup>
+                    <MudToggleGroup T="AppTheme" Value="PreferenceService.SelectedAppTheme" ValueChanged="v => PreferenceService.SelectedAppTheme = v" SelectionMode="SelectionMode.SingleSelection" Size="Size.Small" CheckMark aria-label="Theme for entire app">
+                        <MudToggleItem T="AppTheme" Value="@(AppTheme.Light)">Light</MudToggleItem>
+                        <MudToggleItem T="AppTheme" Value="@(AppTheme.Dark)">Dark</MudToggleItem>
+                        <MudToggleItem T="AppTheme" Value="@(AppTheme.Unspecified)">System</MudToggleItem>
+                    </MudToggleGroup>
 
-                    <MudCheckBox @bind-Value="PreferenceService.HideNotes" aria-label="Hide the notes section on the home page">Hide "Today's notes"</MudCheckBox>
+                    <MudSwitch @bind-Value="PreferenceService.HideNotes" Color="Color.Primary" aria-label="Hide the notes section on the home page">Hide "Today's notes"</MudSwitch>
                 </MudPaper>
             </section>
 

--- a/JournalApp/Pages/SettingsPage.razor.css
+++ b/JournalApp/Pages/SettingsPage.razor.css
@@ -4,11 +4,35 @@
   gap: 16px;
 }
 
-::deep .settings-group {
+/* M3E grouped list, like the home timeline: every setting is its own tonal row, and the first and last rows carry the large group radius. */
+.settings-group {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  padding: 12px;
+  gap: 3px;
+}
+
+::deep .settings-item {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  background-color: var(--mud-palette-surface);
+  border-radius: 6px;
+  padding: 14px 16px;
+}
+
+::deep .settings-item:first-child {
+  border-top-left-radius: 18px;
+  border-top-right-radius: 18px;
+}
+
+::deep .settings-item:last-child {
+  border-bottom-left-radius: 18px;
+  border-bottom-right-radius: 18px;
+}
+
+::deep .settings-item-title {
+  font-size: 16px;
+  font-weight: 500;
 }
 
 .loading-container {

--- a/JournalApp/wwwroot/app.css
+++ b/JournalApp/wwwroot/app.css
@@ -196,13 +196,14 @@ body {
 }
 
 /* M3 switch: 52x32 pill track with an outline, solid colors instead of translucent overlays, and a thumb that grows when checked. */
-.mud-switch-span {
+/* Selectors match MudBlazor's compound size and descendant rules, which otherwise outrank single-class overrides and leave the M2 geometry in place. */
+.mud-switch-span-medium.mud-switch-span {
   width: 52px;
   height: 32px;
   padding: 0;
 }
 
-.mud-switch-track {
+.mud-switch-span .mud-switch-track {
   border-radius: 999px;
   opacity: 1;
   background-color: var(--mud-palette-gray-light);

--- a/JournalApp/wwwroot/app.css
+++ b/JournalApp/wwwroot/app.css
@@ -211,9 +211,11 @@ body {
   box-sizing: border-box;
 }
 
+/* The thumb carrier resizes with the thumb (34px off, 42px on), so it centers via transform instead of a fixed offset. */
 .mud-switch-base {
-  top: -3px;
-  left: -3px;
+  top: 50%;
+  left: -1px;
+  transform: translateY(-50%);
 }
 
 .mud-switch-base:not(.mud-checked) {
@@ -244,9 +246,9 @@ body {
   height: 24px;
 }
 
-/* The checked thumb grows to 24px, so the slide distance shrinks to keep it inset from the track edge. */
+/* The slide distance puts the grown thumb at the M3 insets: 8px from the left edge when off, 4px from the right edge when on. */
 .mud-switch-base.mud-checked {
-  transform: translateX(17px);
+  transform: translateY(-50%) translateX(16px);
 }
 
 /* M3 settings rows lead with the label and keep the switch on the trailing edge. Scoped to the label element because MudSwitch reuses the mud-switch class on its inner text span. */

--- a/JournalApp/wwwroot/app.css
+++ b/JournalApp/wwwroot/app.css
@@ -195,6 +195,67 @@ body {
   box-shadow: none;
 }
 
+/* M3 switch: 52x32 pill track with an outline, solid colors instead of translucent overlays, and a thumb that grows when checked. */
+.mud-switch-span {
+  width: 52px;
+  height: 32px;
+  padding: 0;
+}
+
+.mud-switch-track {
+  border-radius: 999px;
+  opacity: 1;
+  background-color: var(--mud-palette-gray-light);
+  border: 2px solid var(--mud-palette-lines-inputs);
+  box-sizing: border-box;
+}
+
+.mud-switch-base {
+  top: -3px;
+  left: -3px;
+}
+
+.mud-switch-base:not(.mud-checked) {
+  color: var(--mud-palette-lines-inputs) !important;
+}
+
+.mud-switch-base.mud-checked {
+  color: var(--mud-palette-primary-text) !important;
+}
+
+.mud-switch-base.mud-checked + .mud-switch-track {
+  opacity: 1;
+  background-color: var(--mud-palette-primary);
+  border-color: var(--mud-palette-primary);
+}
+
+.mud-switch-thumb-medium {
+  box-shadow: none;
+}
+
+.mud-switch-base:not(.mud-checked) .mud-switch-thumb-medium {
+  width: 16px;
+  height: 16px;
+}
+
+.mud-switch-base.mud-checked .mud-switch-thumb-medium {
+  width: 24px;
+  height: 24px;
+}
+
+/* The checked thumb grows to 24px, so the slide distance shrinks to keep it inset from the track edge. */
+.mud-switch-base.mud-checked {
+  transform: translateX(17px);
+}
+
+/* M3 settings rows lead with the label and keep the switch on the trailing edge. Scoped to the label element because MudSwitch reuses the mud-switch class on its inner text span. */
+.settings-group label.mud-switch {
+  width: 100%;
+  flex-direction: row-reverse;
+  justify-content: space-between;
+  margin-inline-start: 0;
+}
+
 /* M3 menus and popovers sit on surfaceContainerHigh. */
 .mud-popover {
   --mud-palette-surface: var(--mud-palette-gray-lighter);


### PR DESCRIPTION
Settings page plus the shared switch styling:

- **Theme picker**: the Light/Dark/System radio group becomes an M3 segmented button with a checkmark on the selection, matching the toggle groups on the home screen.
- **Hide Today's notes**: the checkbox becomes an M3 switch, laid out as a settings list row with the label leading and the control on the trailing edge.
- **M3 switch shape everywhere**: switches (Settings + category manager) get the M3 treatment: 52x32 outlined pill track, solid track colors instead of the M2 translucent overlay, thumb grows 16px to 24px when checked, no thumb shadow.
