### PR TITLE
Round calendar day cells and mark today with a primary ring

### DIFF
--- a/JournalApp/Pages/Calendar/CalendarMonth.razor.css
+++ b/JournalApp/Pages/Calendar/CalendarMonth.razor.css
@@ -18,6 +18,7 @@
   padding: 1%;
   min-width: 32px;
   max-width: 96px;
+  border-radius: 8px;
   transition: transform 0.1s ease-out;
 }
 
@@ -25,6 +26,8 @@
   transform: scale(0.95);
 }
 
+/* M3 marks today with a solid primary ring instead of a dashed generic outline. */
 ::deep .calendar-day-current {
-  outline: 2px dashed var(--mud-palette-text-primary);
+  outline: 3px solid var(--mud-palette-primary);
+  outline-offset: -3px;
 }


### PR DESCRIPTION
Changes
- Day cells get an 8px corner radius instead of sharp squares.
- Today is marked with a solid 3px ring in the theme primary (inset so it hugs the cell), replacing the dated 2px dashed outline drawn in the text color.

<img width="1123" height="695" alt="image" src="https://github.com/user-attachments/assets/44c70d70-27aa-41ba-b542-b6b401cd2339" />
