### PR TITLE
Add a Material 3 navigation bar and a New note FAB

### DIFF
--- a/JournalApp/Components/NavBar.razor
+++ b/JournalApp/Components/NavBar.razor
@@ -1,0 +1,81 @@
+@namespace JournalApp
+@implements IDisposable
+@inject NavigationManager NavigationManager
+
+@if (_visible)
+{
+    <nav class="nav-bar" aria-label="Main destinations">
+        <button class="nav-bar-item @(ActiveClass("home"))" @onclick="@(() => Go("/"))" aria-label="Home">
+            <span class="nav-bar-indicator"><MudIcon Icon="@Icons.Material.Rounded.Home" /></span>
+            <span class="nav-bar-label">Home</span>
+        </button>
+
+        <button class="nav-bar-item @(ActiveClass("calendar"))" @onclick="@(() => Go($"/calendar/{DateOnly.FromDateTime(DateTime.Now):yyyyMMdd}"))" aria-label="Calendar">
+            <span class="nav-bar-indicator"><MudIcon Icon="@Icons.Material.Rounded.CalendarMonth" /></span>
+            <span class="nav-bar-label">Calendar</span>
+        </button>
+
+        <button class="nav-bar-item @(ActiveClass("trends"))" @onclick="@(() => Go($"/trends/{DateOnly.FromDateTime(DateTime.Now):yyyyMMdd}"))" aria-label="Trends">
+            <span class="nav-bar-indicator"><MudIcon Icon="@Icons.Material.Rounded.ShowChart" /></span>
+            <span class="nav-bar-label">Trends</span>
+        </button>
+    </nav>
+}
+
+@code {
+    string _active = "home";
+    bool _visible = true;
+
+    protected override void OnInitialized()
+    {
+        base.OnInitialized();
+
+        NavigationManager.LocationChanged += OnLocationChanged;
+        UpdateFromUri();
+    }
+
+    void OnLocationChanged(object sender, Microsoft.AspNetCore.Components.Routing.LocationChangedEventArgs e)
+    {
+        UpdateFromUri();
+        StateHasChanged();
+    }
+
+    // The bar only shows on the three top-level destinations; subpages like Settings keep their full-height layouts.
+    void UpdateFromUri()
+    {
+        var path = new Uri(NavigationManager.Uri).AbsolutePath.Trim('/');
+
+        if (path.StartsWith("calendar", StringComparison.OrdinalIgnoreCase))
+        {
+            _active = "calendar";
+            _visible = true;
+        }
+        else if (path.StartsWith("trends", StringComparison.OrdinalIgnoreCase))
+        {
+            _active = "trends";
+            _visible = true;
+        }
+        else if (path.Length == 0 || path.All(char.IsDigit))
+        {
+            _active = "home";
+            _visible = true;
+        }
+        else
+        {
+            _visible = false;
+        }
+    }
+
+    string ActiveClass(string destination) => _active == destination ? "nav-bar-item-active" : null;
+
+    void Go(string url)
+    {
+        if (NavigationManager.Uri != NavigationManager.ToAbsoluteUri(url).ToString())
+            NavigationManager.NavigateTo(url, false, true);
+    }
+
+    public void Dispose()
+    {
+        NavigationManager.LocationChanged -= OnLocationChanged;
+    }
+}

--- a/JournalApp/Components/NavBar.razor.css
+++ b/JournalApp/Components/NavBar.razor.css
@@ -1,0 +1,47 @@
+.nav-bar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: calc(72px + env(safe-area-inset-bottom));
+  padding-bottom: env(safe-area-inset-bottom);
+  display: flex;
+  background-color: var(--mud-palette-surface);
+  z-index: var(--mud-zindex-appbar);
+}
+
+.nav-bar-item {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font: inherit;
+  color: var(--mud-palette-text-secondary);
+}
+
+.nav-bar-indicator {
+  display: grid;
+  place-items: center;
+  width: 64px;
+  height: 32px;
+  border-radius: 999px;
+}
+
+.nav-bar-item-active {
+  color: var(--mud-palette-text-primary);
+}
+
+.nav-bar-item-active .nav-bar-indicator {
+  background-color: var(--mud-palette-secondary-lighten);
+  color: var(--mud-palette-secondary-darken);
+}
+
+.nav-bar-label {
+  font-size: 12px;
+  font-weight: 500;
+}

--- a/JournalApp/Pages/Index.razor
+++ b/JournalApp/Pages/Index.razor
@@ -20,7 +20,6 @@
         <MudMenu Icon="@Icons.Material.Rounded.MoreVert" aria-label="More options" AnchorOrigin="Origin.BottomRight" TransformOrigin="Origin.TopRight">
             <MudMenuItem Icon="@Icons.Material.Rounded.DashboardCustomize" OnClick="ManageCategories" AutoClose="false">Elements</MudMenuItem>
             <MudMenuItem Icon="@Icons.Material.Rounded.Medication" OnClick="ManageMedications" AutoClose="false">Medications</MudMenuItem>
-            <MudMenuItem Icon="@Icons.Material.Rounded.ShowChart" OnClick="OpenTrends" AutoClose="false">Trends</MudMenuItem>
             <MudMenuItem Icon="@Icons.Material.Rounded.LibraryBooks" OnClick="OpenWorksheets" AutoClose="false">Worksheets</MudMenuItem>
 
             @if (PreferenceService.SafetyPlan != null)
@@ -119,18 +118,13 @@
                         </ul>
                     </MudCardContent>
 
-                    <MudCardActions>
-                        @if (group.Key == "Notes")
-                        {
-                            <MudButton Variant="Variant.Outlined" Color="Color.Primary" StartIcon="@Icons.Material.Rounded.Chat" OnClick="NewNote">
-                                New note
-                            </MudButton>
-                        }
-                    </MudCardActions>
+                    <MudCardActions />
                 </MudCard>
             </div>
         }
     </div>
+
+    <MudFab Class="new-note-fab" StartIcon="@Icons.Material.Rounded.Chat" aria-label="New note" OnClick="NewNote" />
 </main>
 
 @code {
@@ -291,12 +285,6 @@
     {
         logger.LogInformation("Opening medication manager");
         NavigationManager.NavigateTo($"/manage/Medications", false, true);
-    }
-
-    void OpenTrends()
-    {
-        logger.LogInformation("Opening Trends");
-        NavigationManager.NavigateTo($"/trends/{_day.Date:yyyyMMdd}", false, true);
     }
 
     void OpenSafetyPlan()

--- a/JournalApp/Pages/Index.razor.css
+++ b/JournalApp/Pages/Index.razor.css
@@ -33,3 +33,15 @@
   display: flex;
   flex-grow: 1;
 }
+
+/* M3 FAB: primaryContainer surface, floating above the navigation bar. */
+::deep .new-note-fab {
+  position: fixed;
+  right: 16px;
+  bottom: calc(88px + env(safe-area-inset-bottom));
+  background-color: var(--mud-palette-primary-lighten);
+  color: var(--mud-palette-primary-darken);
+  border-radius: 16px;
+  box-shadow: var(--mud-elevation-3);
+  z-index: var(--mud-zindex-appbar);
+}

--- a/JournalApp/Pages/MainLayout.razor
+++ b/JournalApp/Pages/MainLayout.razor
@@ -22,6 +22,8 @@
     @Body
 </div>
 
+<NavBar />
+
 @code {
     bool _hasInitiallyRendered;
 

--- a/JournalApp/wwwroot/app.css
+++ b/JournalApp/wwwroot/app.css
@@ -365,3 +365,10 @@ body {
     background-color: #FFF8F9;
   }
 }
+
+/* Bottom snackbars float above the navigation bar instead of covering it. */
+.mud-snackbar-location-bottom-center,
+.mud-snackbar-location-bottom-left,
+.mud-snackbar-location-bottom-right {
+  bottom: calc(88px + env(safe-area-inset-bottom));
+}


### PR DESCRIPTION
One of three parallel MD3 slices (with the Settings controls and calendar today-indicator PRs). The structural one: top-level navigation becomes visible instead of hiding in the overflow menu.

## What changed

- **Navigation bar**: Home, Calendar, and Trends are bottom destinations with the M3 active-pill indicator (secondaryContainer pill, labeled icons). The bar renders only on those three top-level destinations; subpages like Settings and Manage keep their full-height back-arrow layouts. Trends leaves the overflow menu; the calendar keeps its date-button entry too.
- **New note FAB**: the primary action moves from an outlined button inside the notes card to an M3 FAB (primaryContainer, 16px radius) floating above the bar on the home screen.
- **Snackbar clearance**: bottom snackbars lift above the navigation bar instead of covering it.

## Verification

All 233 tests pass. Verified on the Android emulator: navigating between all three destinations updates the active pill, the FAB opens the note dialog, and teaching-tip snackbars sit above the bar. Before/after screenshots attached below.