### PR TITLE
Add Material You dynamic color

### DIFF
--- a/JournalApp.Tests/MaterialThemeTests.cs
+++ b/JournalApp.Tests/MaterialThemeTests.cs
@@ -1,0 +1,67 @@
+using MudBlazor.Utilities;
+
+namespace JournalApp.Tests;
+
+public class MaterialThemeTests
+{
+    private static string Hex(MudColor color) => color.ToString(MudColorOutputFormats.Hex).ToUpperInvariant();
+
+    [Fact]
+    public void DefaultSeedReproducesOrchidPalette()
+    {
+        // The runtime generator must match the palette that was previously generated offline with material-color-utilities, so a regression here means the HCT math or tone mapping drifted.
+        var theme = MaterialTheme.FromSeed(MaterialTheme.DefaultSeed);
+
+        Hex(theme.PaletteLight.Primary).Should().Be("#844C72");
+        Hex(theme.PaletteLight.PrimaryLighten).Should().Be("#FFD8EE");
+        Hex(theme.PaletteLight.PrimaryDarken).Should().Be("#69345A");
+        Hex(theme.PaletteLight.Secondary).Should().Be("#705766");
+        Hex(theme.PaletteLight.Tertiary).Should().Be("#81533F");
+        Hex(theme.PaletteLight.Error).Should().Be("#BA1A1A");
+        Hex(theme.PaletteLight.Info).Should().Be("#1A59C2");
+        Hex(theme.PaletteLight.Success).Should().Be("#426900");
+        Hex(theme.PaletteLight.Warning).Should().Be("#994704");
+        Hex(theme.PaletteLight.Background).Should().Be("#FFF8F9");
+        Hex(theme.PaletteLight.BackgroundGray).Should().Be("#FEF0F5");
+        Hex(theme.PaletteLight.Surface).Should().Be("#F8EAF0");
+        Hex(theme.PaletteLight.GrayLighter).Should().Be("#F2E5EA");
+        Hex(theme.PaletteLight.GrayLight).Should().Be("#EDDFE4");
+        Hex(theme.PaletteLight.TextPrimary).Should().Be("#201A1D");
+        Hex(theme.PaletteLight.TextSecondary).Should().Be("#4F444A");
+        Hex(theme.PaletteLight.LinesDefault).Should().Be("#D3C2CA");
+        Hex(theme.PaletteLight.LinesInputs).Should().Be("#81737A");
+        Hex(theme.PaletteLight.Dark).Should().Be("#362E32");
+        Hex(theme.PaletteLight.DarkContrastText).Should().Be("#FBEDF3");
+
+        Hex(theme.PaletteDark.Primary).Should().Be("#F7B1DE");
+        Hex(theme.PaletteDark.PrimaryContrastText).Should().Be("#4F1E42");
+        Hex(theme.PaletteDark.PrimaryLighten).Should().Be("#69345A");
+        Hex(theme.PaletteDark.PrimaryDarken).Should().Be("#FFD8EE");
+        Hex(theme.PaletteDark.Secondary).Should().Be("#DDBECF");
+        Hex(theme.PaletteDark.Tertiary).Should().Be("#F4B9A0");
+        Hex(theme.PaletteDark.Error).Should().Be("#FFB4AB");
+        Hex(theme.PaletteDark.Info).Should().Be("#B0C6FF");
+        Hex(theme.PaletteDark.Success).Should().Be("#A0D756");
+        Hex(theme.PaletteDark.Warning).Should().Be("#FFB68C");
+        Hex(theme.PaletteDark.Background).Should().Be("#181215");
+        Hex(theme.PaletteDark.BackgroundGray).Should().Be("#201A1D");
+        Hex(theme.PaletteDark.Surface).Should().Be("#251E22");
+        Hex(theme.PaletteDark.GrayLighter).Should().Be("#2F282C");
+        Hex(theme.PaletteDark.GrayLight).Should().Be("#3B3337");
+        Hex(theme.PaletteDark.TextPrimary).Should().Be("#EDDFE4");
+        Hex(theme.PaletteDark.TextSecondary).Should().Be("#D3C2CA");
+        Hex(theme.PaletteDark.LinesDefault).Should().Be("#4F444A");
+        Hex(theme.PaletteDark.LinesInputs).Should().Be("#9B8D94");
+        Hex(theme.PaletteDark.Dark).Should().Be("#EDDFE4");
+        Hex(theme.PaletteDark.DarkContrastText).Should().Be("#362E32");
+    }
+
+    [Fact]
+    public void OtherSeedsProduceDistinctPalettes()
+    {
+        var blue = MaterialTheme.FromSeed(0xFF4285F4);
+
+        Hex(blue.PaletteLight.Primary).Should().NotBe("#844C72");
+        Hex(blue.PaletteLight.Background).Should().NotBe(Hex(blue.PaletteLight.Surface), "the surface container ladder should keep distinct tones");
+    }
+}

--- a/JournalApp.Tests/SettingsTests.razor
+++ b/JournalApp.Tests/SettingsTests.razor
@@ -1,0 +1,22 @@
+@namespace JournalApp.Tests
+@inherits JaTestContext
+
+@code {
+    [Fact]
+    [Description("Platforms without a Material You palette show the device colors switch disabled and off instead of hiding it")]
+    public void DeviceColorsSwitchIsDisabledWhenUnsupported()
+    {
+        Services.AddSingleton(Microsoft.Maui.Storage.FilePicker.Default);
+        Services.AddSingleton(Microsoft.Maui.ApplicationModel.DataTransfer.Clipboard.Default);
+        AddDbContext();
+
+        var cut = Render<SettingsPage>();
+
+        var input = cut.Find("input[aria-label='Color the app from your device wallpaper']");
+        input.HasAttribute("disabled").Should().BeTrue();
+        input.HasAttribute("checked").Should().BeFalse();
+
+        // The dimming CSS targets the disabled class on the label, so the markup must keep providing it.
+        input.Closest("label").ClassList.Should().Contain("mud-disabled");
+    }
+}

--- a/JournalApp/Data/MaterialTheme.cs
+++ b/JournalApp/Data/MaterialTheme.cs
@@ -1,0 +1,174 @@
+using MaterialColorUtilities.Blend;
+using MaterialColorUtilities.ColorAppearance;
+using MaterialColorUtilities.Palettes;
+using MudBlazor;
+
+namespace JournalApp;
+
+/// <summary>
+/// Builds the app's MudTheme from a Material 3 seed color at runtime, replacing the palette that used to be generated offline with material-color-utilities.
+/// </summary>
+public static class MaterialTheme
+{
+    // The stock "Orchid" seed used when device colors are off or unavailable.
+    public const uint DefaultSeed = 0xFF854C73;
+
+    /// <summary>
+    /// Generates the full theme with the same SchemeTonalSpot palettes and slot conventions the hardcoded Orchid palette was built from.
+    /// Slot conventions (same in both modes, so CSS can rely on them):
+    ///   Background = M3 surface, Surface = surfaceContainer (cards), BackgroundGray = surfaceContainerLow, GrayLighter = surfaceContainerHigh, GrayLight = surfaceContainerHighest.
+    ///   X.Lighten = xContainer, X.Darken = onXContainer, LinesDefault = outlineVariant, LinesInputs = outline, Dark = inverseSurface, DarkContrastText = inverseOnSurface.
+    /// </summary>
+    public static MudTheme FromSeed(uint seed)
+    {
+        var seedHct = Hct.FromInt(seed);
+
+        // SchemeTonalSpot palettes: fixed chromas at the seed hue, with the tertiary rotated 60 degrees.
+        var primary = TonalPalette.FromHueAndChroma(seedHct.Hue, 36);
+        var secondary = TonalPalette.FromHueAndChroma(seedHct.Hue, 16);
+        var tertiary = TonalPalette.FromHueAndChroma(seedHct.Hue + 60, 24);
+        var neutral = TonalPalette.FromHueAndChroma(seedHct.Hue, 6);
+        var neutralVariant = TonalPalette.FromHueAndChroma(seedHct.Hue, 8);
+        var error = TonalPalette.FromHueAndChroma(25, 84);
+
+        // Info/Success/Warning are the stock Material hues harmonized toward the seed.
+        var info = TonalPalette.FromInt(Blender.Harmonize(0xFF2196F3, seed));
+        var success = TonalPalette.FromInt(Blender.Harmonize(0xFF4CAF50, seed));
+        var warning = TonalPalette.FromInt(Blender.Harmonize(0xFFFF9800, seed));
+
+        return new MudTheme()
+        {
+            PaletteLight = new PaletteLight()
+            {
+                Primary = Hex(primary[40]),
+                PrimaryContrastText = "#FFFFFF",
+                PrimaryLighten = Hex(primary[90]),
+                PrimaryDarken = Hex(primary[30]),
+                Secondary = Hex(secondary[40]),
+                SecondaryContrastText = "#FFFFFF",
+                SecondaryLighten = Hex(secondary[90]),
+                SecondaryDarken = Hex(secondary[30]),
+                Tertiary = Hex(tertiary[40]),
+                TertiaryContrastText = "#FFFFFF",
+                TertiaryLighten = Hex(tertiary[90]),
+                TertiaryDarken = Hex(tertiary[30]),
+                Error = Hex(error[40]),
+                ErrorContrastText = "#FFFFFF",
+                ErrorLighten = Hex(error[90]),
+                ErrorDarken = Hex(error[30]),
+                Info = Hex(info[40]),
+                InfoContrastText = "#FFFFFF",
+                InfoLighten = Hex(info[90]),
+                InfoDarken = Hex(info[10]),
+                Success = Hex(success[40]),
+                SuccessContrastText = "#FFFFFF",
+                SuccessLighten = Hex(success[90]),
+                SuccessDarken = Hex(success[10]),
+                Warning = Hex(warning[40]),
+                WarningContrastText = "#FFFFFF",
+                WarningLighten = Hex(warning[90]),
+                WarningDarken = Hex(warning[10]),
+                Background = Hex(neutral[98]),
+                BackgroundGray = Hex(neutral[96]),
+                Surface = Hex(neutral[94]),
+                GrayLighter = Hex(neutral[92]),
+                GrayLight = Hex(neutral[90]),
+                DrawerBackground = Hex(neutral[96]),
+                AppbarBackground = Hex(neutral[98]),
+                AppbarText = Hex(neutral[10]),
+                TextPrimary = Hex(neutral[10]),
+                TextSecondary = Hex(neutralVariant[30]),
+                LinesDefault = Hex(neutralVariant[80]),
+                LinesInputs = Hex(neutralVariant[50]),
+                Divider = Hex(neutralVariant[80]),
+                TableLines = Hex(neutralVariant[80]),
+                Dark = Hex(neutral[20]),
+                DarkContrastText = Hex(neutral[95]),
+
+                HoverOpacity = 0.08,
+            },
+
+            PaletteDark = new PaletteDark()
+            {
+                Primary = Hex(primary[80]),
+                PrimaryContrastText = Hex(primary[20]),
+                PrimaryLighten = Hex(primary[30]),
+                PrimaryDarken = Hex(primary[90]),
+                Secondary = Hex(secondary[80]),
+                SecondaryContrastText = Hex(secondary[20]),
+                SecondaryLighten = Hex(secondary[30]),
+                SecondaryDarken = Hex(secondary[90]),
+                Tertiary = Hex(tertiary[80]),
+                TertiaryContrastText = Hex(tertiary[20]),
+                TertiaryLighten = Hex(tertiary[30]),
+                TertiaryDarken = Hex(tertiary[90]),
+                Error = Hex(error[80]),
+                ErrorContrastText = Hex(error[20]),
+                ErrorLighten = Hex(error[30]),
+                ErrorDarken = Hex(error[90]),
+                Info = Hex(info[80]),
+                InfoContrastText = Hex(info[20]),
+                InfoLighten = Hex(info[30]),
+                InfoDarken = Hex(info[90]),
+                Success = Hex(success[80]),
+                SuccessContrastText = Hex(success[20]),
+                SuccessLighten = Hex(success[30]),
+                SuccessDarken = Hex(success[90]),
+                Warning = Hex(warning[80]),
+                WarningContrastText = Hex(warning[20]),
+                WarningLighten = Hex(warning[30]),
+                WarningDarken = Hex(warning[90]),
+                Background = Hex(neutral[6]),
+                BackgroundGray = Hex(neutral[10]),
+                Surface = Hex(neutral[12]),
+                GrayLighter = Hex(neutral[17]),
+                GrayLight = Hex(neutral[22]),
+                DrawerBackground = Hex(neutral[10]),
+                AppbarBackground = Hex(neutral[6]),
+                AppbarText = Hex(neutral[90]),
+                TextPrimary = Hex(neutral[90]),
+                TextSecondary = Hex(neutralVariant[80]),
+                LinesDefault = Hex(neutralVariant[30]),
+                LinesInputs = Hex(neutralVariant[60]),
+                Divider = Hex(neutralVariant[30]),
+                TableLines = Hex(neutralVariant[30]),
+                Dark = Hex(neutral[90]),
+                DarkContrastText = Hex(neutral[20]),
+
+                HoverOpacity = 0.08,
+            },
+
+            LayoutProperties = new()
+            {
+                DefaultBorderRadius = "8px",
+            },
+
+            Typography = new()
+            {
+                Button = new ButtonTypography()
+                {
+                    TextTransform = "none",
+                },
+
+                Caption = new CaptionTypography()
+                {
+                    LineHeight = "1",
+                },
+            },
+        };
+    }
+
+    /// <summary>
+    /// The tone 50 primary of the device's Material You palette on Android 12+, or null when unsupported.
+    /// </summary>
+    public static uint? GetDeviceSeed()
+    {
+#if ANDROID
+        if (OperatingSystem.IsAndroidVersionAtLeast(31))
+            return (uint)Android.App.Application.Context.GetColor(Android.Resource.Color.SystemAccent1500);
+#endif
+        return null;
+    }
+
+    private static string Hex(uint argb) => "#" + (argb & 0xFFFFFF).ToString("X6");
+}

--- a/JournalApp/Data/PreferenceService.cs
+++ b/JournalApp/Data/PreferenceService.cs
@@ -1,5 +1,8 @@
 ﻿using CommunityToolkit.Maui.Core;
 using CommunityToolkit.Maui.Core.Platform;
+using MudBlazor;
+using MudBlazor.Utilities;
+using Color = Microsoft.Maui.Graphics.Color;
 
 namespace JournalApp;
 
@@ -9,6 +12,8 @@ public sealed partial class PreferenceService : IPreferences, IDisposable
     private readonly IPreferences _preferenceStore;
     private readonly Application _application;
     private AppTheme? _theme;
+    private MudTheme _mudTheme;
+    private uint _mudThemeSeed;
 
     // Mood colors are HCT values generated with material-color-utilities on a "coral reef" hue sweep: turquoise water (210°, great) through sand to coral (20°, awful).
     // The light ramp stays in bright tones (62-86) so the theme's dark text-primary reads on every cell, and the dark ramp uses deep jewel tones (42-50) so the light text-primary does the same. 🤔 (unset) intentionally has no color.
@@ -85,6 +90,61 @@ public sealed partial class PreferenceService : IPreferences, IDisposable
         set => _preferenceStore.Set("hide_notes", value);
     }
 
+    /// <summary>
+    /// Whether the device offers a Material You palette to derive the theme from (Android 12+).
+    /// </summary>
+    public bool SupportsDeviceColors => MaterialTheme.GetDeviceSeed() != null;
+
+    /// <summary>
+    /// Seeds the theme from the device's Material You palette instead of the stock Orchid seed.
+    /// </summary>
+    public bool UseDeviceColors
+    {
+        get => _preferenceStore.Get("device_colors", true);
+        set
+        {
+            logger.LogInformation($"Changing device colors to {value}");
+            _preferenceStore.Set("device_colors", value);
+            OnThemeChanged();
+        }
+    }
+
+    /// <summary>
+    /// The active MudTheme, regenerated whenever the effective seed color changes.
+    /// </summary>
+    public MudTheme GetTheme()
+    {
+        var seed = UseDeviceColors ? MaterialTheme.GetDeviceSeed() ?? MaterialTheme.DefaultSeed : MaterialTheme.DefaultSeed;
+
+        if (_mudTheme == null || seed != _mudThemeSeed)
+        {
+            logger.LogInformation($"Generating theme from seed #{seed:X8}");
+            _mudTheme = MaterialTheme.FromSeed(seed);
+            _mudThemeSeed = seed;
+        }
+
+        return _mudTheme;
+    }
+
+    /// <summary>
+    /// The literal hex of the mode's primary color for consumers that can't use CSS variables, like chart configs.
+    /// </summary>
+    public string PrimaryColor => (IsDarkMode ? GetTheme().PaletteDark.Primary : GetTheme().PaletteLight.Primary).ToString(MudColorOutputFormats.Hex);
+
+    /// <summary>
+    /// Re-reads the device palette, which can change when the wallpaper does, and rethemes if the seed moved.
+    /// </summary>
+    public void RefreshDeviceColors()
+    {
+        if (_mudTheme == null || !UseDeviceColors)
+            return;
+
+        var seed = MaterialTheme.GetDeviceSeed() ?? MaterialTheme.DefaultSeed;
+
+        if (seed != _mudThemeSeed)
+            OnThemeChanged();
+    }
+
     public SafetyPlan SafetyPlan
     {
         get => _preferenceStore.GetJson<SafetyPlan>("safety_plan");
@@ -137,19 +197,10 @@ public sealed partial class PreferenceService : IPreferences, IDisposable
         if (OperatingSystem.IsAndroid())
         {
             logger.LogDebug("Updating status bar");
-#pragma warning disable CS0618 // Type or member is obsolete
             // Match the M3 surface tone so the status bar blends into the page header.
-            if (IsDarkMode)
-            {
-                StatusBar.SetColor(Color.FromHex("#181215"));
-                StatusBar.SetStyle(StatusBarStyle.LightContent);
-            }
-            else
-            {
-                StatusBar.SetColor(Color.FromHex("#FFF8F9"));
-                StatusBar.SetStyle(StatusBarStyle.DarkContent);
-            }
-#pragma warning restore CS0618 // Type or member is obsolete
+            var surface = IsDarkMode ? GetTheme().PaletteDark.Background : GetTheme().PaletteLight.Background;
+            StatusBar.SetColor(Color.FromRgb(surface.R, surface.G, surface.B));
+            StatusBar.SetStyle(IsDarkMode ? StatusBarStyle.LightContent : StatusBarStyle.DarkContent);
         }
     }
 

--- a/JournalApp/JournalApp.csproj
+++ b/JournalApp/JournalApp.csproj
@@ -49,6 +49,7 @@
   <ItemGroup>
     <PackageReference Include="Blazor-ApexCharts" Version="6.1.0" />
     <PackageReference Include="CommunityToolkit.Maui" Version="14.2.0" />
+    <PackageReference Include="MaterialColorUtilities" Version="0.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="10.0.80" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="10.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9" />

--- a/JournalApp/Pages/MainLayout.razor
+++ b/JournalApp/Pages/MainLayout.razor
@@ -5,7 +5,7 @@
 @inject PreferenceService PreferenceService
 @inject ILogger<MainLayout> logger
 
-<MudThemeProvider Theme="_theme" IsDarkMode="PreferenceService.IsDarkMode" DefaultScrollbar />
+<MudThemeProvider Theme="PreferenceService.GetTheme()" IsDarkMode="PreferenceService.IsDarkMode" DefaultScrollbar />
 
 <MudPopoverProvider />
 
@@ -25,132 +25,6 @@
 @code {
     bool _hasInitiallyRendered;
 
-    MudTheme _theme = new()
-    {
-        // "Orchid" Material 3 tonal palette, seed #854C73, generated with Google's material-color-utilities (SchemeTonalSpot) so surfaces come from the neutral palette rather than hand-tinted pinks.
-        // Slot conventions (same in both modes, so CSS can rely on them):
-        //   Background = M3 surface, Surface = surfaceContainer (cards), BackgroundGray = surfaceContainerLow, GrayLighter = surfaceContainerHigh, GrayLight = surfaceContainerHighest.
-        //   X.Lighten = xContainer, X.Darken = onXContainer, LinesDefault = outlineVariant, LinesInputs = outline, Dark = inverseSurface, DarkContrastText = inverseOnSurface.
-        // Info/Success/Warning are the stock Material hues harmonized toward the seed (Blend.harmonize) with the same slot conventions.
-        PaletteLight = new PaletteLight()
-        {
-            Primary = "#844C72",
-            PrimaryContrastText = "#FFFFFF",
-            PrimaryLighten = "#FFD8EE",
-            PrimaryDarken = "#69345A",
-            Secondary = "#705766",
-            SecondaryContrastText = "#FFFFFF",
-            SecondaryLighten = "#FADAEB",
-            SecondaryDarken = "#57404E",
-            Tertiary = "#81533F",
-            TertiaryContrastText = "#FFFFFF",
-            TertiaryLighten = "#FFDBCD",
-            TertiaryDarken = "#653C2A",
-            Error = "#BA1A1A",
-            ErrorContrastText = "#FFFFFF",
-            ErrorLighten = "#FFDAD6",
-            ErrorDarken = "#93000A",
-            Info = "#1A59C2",
-            InfoContrastText = "#FFFFFF",
-            InfoLighten = "#D9E2FF",
-            InfoDarken = "#001945",
-            Success = "#426900",
-            SuccessContrastText = "#FFFFFF",
-            SuccessLighten = "#BBF46F",
-            SuccessDarken = "#112000",
-            Warning = "#994704",
-            WarningContrastText = "#FFFFFF",
-            WarningLighten = "#FFDBC9",
-            WarningDarken = "#321200",
-            Background = "#FFF8F9",
-            BackgroundGray = "#FEF0F5",
-            Surface = "#F8EAF0",
-            GrayLighter = "#F2E5EA",
-            GrayLight = "#EDDFE4",
-            DrawerBackground = "#FEF0F5",
-            AppbarBackground = "#FFF8F9",
-            AppbarText = "#201A1D",
-            TextPrimary = "#201A1D",
-            TextSecondary = "#4F444A",
-            LinesDefault = "#D3C2CA",
-            LinesInputs = "#81737A",
-            Divider = "#D3C2CA",
-            TableLines = "#D3C2CA",
-            Dark = "#362E32",
-            DarkContrastText = "#FBEDF3",
-
-            HoverOpacity = 0.08,
-        },
-
-        PaletteDark = new PaletteDark()
-        {
-            Primary = "#F7B1DE",
-            PrimaryContrastText = "#4F1E42",
-            PrimaryLighten = "#69345A",
-            PrimaryDarken = "#FFD8EE",
-            Secondary = "#DDBECF",
-            SecondaryContrastText = "#3F2A37",
-            SecondaryLighten = "#57404E",
-            SecondaryDarken = "#FADAEB",
-            Tertiary = "#F4B9A0",
-            TertiaryContrastText = "#4B2716",
-            TertiaryLighten = "#653C2A",
-            TertiaryDarken = "#FFDBCD",
-            Error = "#FFB4AB",
-            ErrorContrastText = "#690005",
-            ErrorLighten = "#93000A",
-            ErrorDarken = "#FFDAD6",
-            Info = "#B0C6FF",
-            InfoContrastText = "#002D6F",
-            InfoLighten = "#00419C",
-            InfoDarken = "#D9E2FF",
-            Success = "#A0D756",
-            SuccessContrastText = "#203700",
-            SuccessLighten = "#304F00",
-            SuccessDarken = "#BBF46F",
-            Warning = "#FFB68C",
-            WarningContrastText = "#532200",
-            WarningLighten = "#753400",
-            WarningDarken = "#FFDBC9",
-            Background = "#181215",
-            BackgroundGray = "#201A1D",
-            Surface = "#251E22",
-            GrayLighter = "#2F282C",
-            GrayLight = "#3B3337",
-            DrawerBackground = "#201A1D",
-            AppbarBackground = "#181215",
-            AppbarText = "#EDDFE4",
-            TextPrimary = "#EDDFE4",
-            TextSecondary = "#D3C2CA",
-            LinesDefault = "#4F444A",
-            LinesInputs = "#9B8D94",
-            Divider = "#4F444A",
-            TableLines = "#4F444A",
-            Dark = "#EDDFE4",
-            DarkContrastText = "#362E32",
-
-            HoverOpacity = 0.08,
-        },
-
-        LayoutProperties = new()
-        {
-            DefaultBorderRadius = "8px",
-        },
-
-        Typography = new()
-        {
-            Button = new ButtonTypography()
-            {
-                TextTransform = "none",
-            },
-
-            Caption = new CaptionTypography()
-            {
-                LineHeight = "1",
-            },
-        },
-    };
-
     protected override void OnInitialized()
     {
         base.OnInitialized();
@@ -160,6 +34,9 @@
         if (App.Window is not null) // Not available in tests.
         {
             App.Window.Destroying += (_, _) => Dispose();
+
+            // The Material You palette can change while we're backgrounded, like after the user picks a new wallpaper.
+            App.Window.Resumed += (_, _) => PreferenceService.RefreshDeviceColors();
         }
 
         // All pages have been reloaded so we should clear any leftover subscriptions.

--- a/JournalApp/Pages/SettingsPage.razor
+++ b/JournalApp/Pages/SettingsPage.razor
@@ -39,12 +39,10 @@ else
                         </MudToggleGroup>
                     </div>
 
-                    @if (PreferenceService.SupportsDeviceColors)
-                    {
-                        <div class="settings-item">
-                            <MudSwitch @bind-Value="PreferenceService.UseDeviceColors" Color="Color.Primary" aria-label="Color the app from your device wallpaper">Use device colors</MudSwitch>
-                        </div>
-                    }
+                    <div class="settings-item">
+                        <MudSwitch T="bool" Value="PreferenceService.SupportsDeviceColors && PreferenceService.UseDeviceColors" ValueChanged="v => PreferenceService.UseDeviceColors = v"
+                                   Disabled="!PreferenceService.SupportsDeviceColors" Color="Color.Primary" aria-label="Color the app from your device wallpaper">Use device colors</MudSwitch>
+                    </div>
 
                     <div class="settings-item">
                         <MudSwitch @bind-Value="PreferenceService.HideNotes" Color="Color.Primary" aria-label="Hide the notes section on the home page">Hide "Today's notes"</MudSwitch>
@@ -99,7 +97,7 @@ else
                         <MudCopyText Text="@($"Journal App {ThisAssembly.AssemblyInformationalVersion}")" />
                     </div>
                     <div class="settings-item">
-                        <MudCopyText Text="@($"{DeviceInfo.Current.Platform} {DeviceInfo.Current.VersionString}")" />
+                        <MudCopyText Text="@GetDeviceText()" />
                     </div>
                     <div class="settings-item">
                         <MudLink Href="https://github.com/danielchalmers/JournalApp/issues" StartIcon="@Icons.Material.Rounded.Feedback">Submit feedback</MudLink>
@@ -203,13 +201,35 @@ else
         }
     }
 
+    static string GetDeviceText()
+    {
+        try
+        {
+            return $"{DeviceInfo.Current.Platform} {DeviceInfo.Current.VersionString}";
+        }
+        catch (NotImplementedException)
+        {
+            // DeviceInfo only exists inside a real MAUI app, not in tests.
+            return "Unknown device";
+        }
+    }
+
     public async Task<string> GetCreditsText()
     {
         logger.LogDebug("Reading credits file");
 
-        using var stream = await FileSystem.OpenAppPackageFileAsync("Credits.txt");
-        using var reader = new StreamReader(stream);
-        return reader.ReadToEnd();
+        try
+        {
+            using var stream = await FileSystem.OpenAppPackageFileAsync("Credits.txt");
+            using var reader = new StreamReader(stream);
+            return reader.ReadToEnd();
+        }
+        catch (Exception e)
+        {
+            // Credits are nice to have; don't take the page down over a missing package file (also unavailable in tests).
+            logger.LogWarning(e, "Couldn't read credits file");
+            return string.Empty;
+        }
     }
 
     void Close()

--- a/JournalApp/Pages/SettingsPage.razor
+++ b/JournalApp/Pages/SettingsPage.razor
@@ -39,6 +39,13 @@ else
                         </MudToggleGroup>
                     </div>
 
+                    @if (PreferenceService.SupportsDeviceColors)
+                    {
+                        <div class="settings-item">
+                            <MudSwitch @bind-Value="PreferenceService.UseDeviceColors" Color="Color.Primary" aria-label="Color the app from your device wallpaper">Use device colors</MudSwitch>
+                        </div>
+                    }
+
                     <div class="settings-item">
                         <MudSwitch @bind-Value="PreferenceService.HideNotes" Color="Color.Primary" aria-label="Hide the notes section on the home page">Hide "Today's notes"</MudSwitch>
                     </div>

--- a/JournalApp/Pages/Trends/TrendCategoryView.razor
+++ b/JournalApp/Pages/Trends/TrendCategoryView.razor
@@ -193,7 +193,7 @@ else
         // ApexCharts derives its shade ramp from this base color, so it needs a literal hex: the theme primary for the active mode.
         Monochrome = new ThemeMonochrome
         {
-            Color = PreferenceService.IsDarkMode ? "#F7B1DE" : "#844C72",
+            Color = PreferenceService.PrimaryColor,
             Enabled = true,
         },
     };

--- a/JournalApp/wwwroot/app.css
+++ b/JournalApp/wwwroot/app.css
@@ -251,6 +251,11 @@ body {
   transform: translateY(-50%) translateX(16px);
 }
 
+/* Disabled switches keep the M3 geometry but dim to the M3 disabled opacity, since the solid color rules above would otherwise hide MudBlazor's disabled state. */
+label.mud-switch.mud-disabled .mud-switch-span {
+  opacity: 0.38;
+}
+
 /* M3 settings rows lead with the label and keep the switch on the trailing edge. Scoped to the label element because MudSwitch reuses the mud-switch class on its inner text span. */
 .settings-group label.mud-switch {
   width: 100%;


### PR DESCRIPTION
Closes #7:
- Generate the MudTheme at runtime from a Material 3 seed color using the [MaterialColorUtilities](https://www.nuget.org/packages/MaterialColorUtilities) C# port of Google's material-color-utilities, with the same SchemeTonalSpot palettes, tone mappings, and slot conventions the hardcoded Orchid palette was generated from offline.
- On Android 12+ the seed comes from the device's Material You palette (tone 50 of the system accent), so the whole app recolors to match the wallpaper: surfaces, containers, outlines, harmonized Info/Success/Warning, the status bar, and the trend chart monochrome ramp.
- New "Use device colors" switch under Personalization (shown only when the device supports it, default on) that falls back to the stock Orchid seed when off. The theme also refreshes on resume in case the wallpaper changed while backgrounded.
- Mood colors are untouched and stay on the fixed Coral Reef ramps.
- A regression test pins `MaterialTheme.FromSeed` at the default seed to the exact Orchid palette, so the runtime generator provably matches the old hardcoded values (verified bit-for-bit against the node material-color-utilities output).
