### PR TITLE
Improve themed launcher icon

### DIFF
--- a/JournalApp/Platforms/Android/Resources/drawable/appicon_monochrome.xml
+++ b/JournalApp/Platforms/Android/Resources/drawable/appicon_monochrome.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Themed-icon layer: the foreground smiley shrunk to sit in the plate like stock Google glyphs, since the full-bleed foreground renders oversized when the launcher tints it. -->
+<inset xmlns:android="http://schemas.android.com/apk/res/android"
+    android:drawable="@mipmap/appicon_foreground"
+    android:insetLeft="18%"
+    android:insetTop="18%"
+    android:insetRight="18%"
+    android:insetBottom="18%" />

--- a/JournalApp/Platforms/Android/Resources/mipmap-anydpi-v26/appicon.xml
+++ b/JournalApp/Platforms/Android/Resources/mipmap-anydpi-v26/appicon.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Replaces the Resizetizer-generated adaptive icon so the monochrome layer can use the inset drawable instead of the full-bleed foreground. -->
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@mipmap/appicon_background" />
+    <foreground android:drawable="@mipmap/appicon_foreground" />
+    <monochrome android:drawable="@drawable/appicon_monochrome" />
+</adaptive-icon>


### PR DESCRIPTION
Finishes the Material You story from #103 on the launcher side. It turns out .NET 10's Resizetizer already emits a `<monochrome>` layer for Android 13+ themed icons, so the smiley was themeable out of the box, but it reuses the full-bleed foreground and the glyph rendered noticeably oversized next to stock icons (filling ~85% of the plate where Google glyphs sit around half).

- Adds a local `mipmap-anydpi-v26/appicon.xml` that overrides the Resizetizer-generated adaptive icon (verified via `aapt2 dump` that the local resource wins in the APK).
- Points the monochrome layer at an 18% inset wrapper around the existing foreground, so the themed glyph now matches the visual weight of the stock Google icons. Reusing the foreground means the rotated debug variant is inherited automatically and there's still a single source of truth for the artwork.
- No change to the regular full-color icon in any launcher mode.

<img width="1560" height="1700" alt="themed-icon-detail" src="https://github.com/user-attachments/assets/fb8f5f2d-416a-4820-8419-6f902f594add" />
<img width="1560" height="1700" alt="themed-icon-home" src="https://github.com/user-attachments/assets/856c5620-fa7c-4a64-bf30-a868e9e922de" />
