### PR TITLE
Update Worksheets and Safety Plan for M3E grouped-list pattern

### DIFF
--- a/JournalApp/Pages/SafetyPlanning/SafetyPlanItem.razor
+++ b/JournalApp/Pages/SafetyPlanning/SafetyPlanItem.razor
@@ -1,7 +1,11 @@
 ﻿@namespace JournalApp
 
 <section class="@($"safety-plan-item safety-plan-item-{MarkupUtil.ToClassName(Title)}")">
-    <MudText>@Subtitle</MudText>
+    <div class="safety-plan-item-header">
+        <MudText Class="safety-plan-item-title">@Title</MudText>
+
+        <MudText Class="safety-plan-item-subtitle" Typo="Typo.body2">@Subtitle</MudText>
+    </div>
 
     <MudTextField T="string" @bind-Text="Text" Placeholder="@Placeholder"
                   Typo="Typo.body2" Variant="Variant.Outlined" Immediate Underline="false"

--- a/JournalApp/Pages/SafetyPlanning/SafetyPlanPage.razor.css
+++ b/JournalApp/Pages/SafetyPlanning/SafetyPlanPage.razor.css
@@ -1,8 +1,40 @@
+/* M3E grouped list, like Settings: every plan item is its own tonal row, and the first and last rows carry the large group radius. */
 .safety-plan-items-container {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 3px;
 }
 
-::deep safety-plan-item {
+::deep .safety-plan-item {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  background-color: var(--mud-palette-surface);
+  border-radius: 6px;
+  padding: 14px 16px;
+}
+
+::deep .safety-plan-item:first-child {
+  border-top-left-radius: 18px;
+  border-top-right-radius: 18px;
+}
+
+::deep .safety-plan-item:last-child {
+  border-bottom-left-radius: 18px;
+  border-bottom-right-radius: 18px;
+}
+
+::deep .safety-plan-item-header {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+::deep .safety-plan-item-title {
+  font-size: 16px;
+  font-weight: 500;
+}
+
+::deep .safety-plan-item-subtitle {
+  color: var(--mud-palette-text-secondary);
 }

--- a/JournalApp/Pages/Worksheets/WorksheetView.razor
+++ b/JournalApp/Pages/Worksheets/WorksheetView.razor
@@ -2,13 +2,13 @@
 @inject ILogger<WorksheetView> logger
 
 <li class="worksheet-view">
-    <MudLink OnClick="OnResourceClicked" Color="Color.Primary" aria-label="Open worksheet" StartIcon="@Icons.Material.Rounded.Link">
+    <MudLink Class="worksheet-view-title" OnClick="OnResourceClicked" Color="Color.Primary" aria-label="Open worksheet" StartIcon="@Icons.Material.Rounded.Link">
         @Worksheet.Title
     </MudLink>
 
     @if (!string.IsNullOrEmpty(Worksheet.Description))
     {
-        <MudText Typo="Typo.body1">@Worksheet.Description</MudText>
+        <MudText Class="worksheet-view-description" Typo="Typo.body2">@Worksheet.Description</MudText>
     }
 </li>
 

--- a/JournalApp/Pages/Worksheets/WorksheetsPage.razor
+++ b/JournalApp/Pages/Worksheets/WorksheetsPage.razor
@@ -22,8 +22,7 @@
                     {
                         <li class="worksheet-group-toc-item">
                             <MudLink OnClick="async () => await ScrollToGroup(MarkupUtil.ToClassName(group.Key))"
-                                     aria-label="Scroll to group"
-                                     StartIcon="@Icons.Material.Rounded.Label">
+                                     aria-label="Scroll to group">
                                 @group.Key
                             </MudLink>
                         </li>
@@ -40,19 +39,12 @@
                     <MudText Class="list-group-title">@group.Key</MudText>
                 }
 
-                <MudCard>
-                    <ul class="worksheet-group-items">
-                        @foreach (var ws in group)
-                        {
-                            <WorksheetView Worksheet="ws" />
-
-                            if (ws != group.Last())
-                            {
-                                <MudDivider />
-                            }
-                        }
-                    </ul>
-                </MudCard>
+                <ul class="worksheet-group-items">
+                    @foreach (var ws in group)
+                    {
+                        <WorksheetView Worksheet="ws" />
+                    }
+                </ul>
             </div>
         }
     </div>

--- a/JournalApp/Pages/Worksheets/WorksheetsPage.razor.css
+++ b/JournalApp/Pages/Worksheets/WorksheetsPage.razor.css
@@ -9,23 +9,14 @@
   flex-direction: column;
 }
 
+/* M3E grouped list, like Settings: every worksheet is its own tonal row, and the first and last rows carry the large group radius. */
 .worksheet-group-items {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-}
-
-.worksheet-group-toc {
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  gap: 8px;
+  gap: 3px;
   list-style-type: none;
-}
-
-.worksheet-group-toc-item {
-  white-space: nowrap;
-  align-items: start;
+  padding: 0;
+  margin: 0;
 }
 
 ::deep .worksheet-view {
@@ -33,4 +24,50 @@
   flex-direction: column;
   align-items: start;
   gap: 4px;
+  background-color: var(--mud-palette-surface);
+  border-radius: 6px;
+  padding: 14px 16px;
+}
+
+::deep .worksheet-view:first-child {
+  border-top-left-radius: 18px;
+  border-top-right-radius: 18px;
+}
+
+::deep .worksheet-view:last-child {
+  border-bottom-left-radius: 18px;
+  border-bottom-right-radius: 18px;
+}
+
+::deep .worksheet-view-title {
+  font-size: 16px;
+  font-weight: 500;
+}
+
+::deep .worksheet-view-description {
+  color: var(--mud-palette-text-secondary);
+}
+
+/* The table of contents reads as a wrapped row of M3 suggestion chips. */
+.worksheet-group-toc {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: 8px;
+  list-style-type: none;
+  padding: 0;
+  margin: 0;
+}
+
+.worksheet-group-toc-item {
+  white-space: nowrap;
+  border: 1px solid var(--mud-palette-lines-default);
+  border-radius: 8px;
+  padding: 6px 12px;
+}
+
+.worksheet-group-toc-item ::deep .mud-link {
+  color: var(--mud-palette-text-primary);
+  font-size: 14px;
+  font-weight: 500;
 }


### PR DESCRIPTION
Continues the MD3E makeover across the remaining pages. Home, Settings, Elements, Calendar, and the theme itself are done, so this pass covers the two screens still on the old flat layout:

- **Worksheets**: the divider-separated MudCard becomes the same M3E grouped list as Settings and the home timeline (tonal rows, 3px gaps, 18px outer radii). The table of contents renders as a wrapped row of M3 suggestion chips instead of inline links with tag icons, worksheet titles read as title-medium links, and descriptions drop to body2 on the secondary ink.
- **Safety Plan**: each plan item becomes a tonal grouped row with a real title (Warning Signs, Coping Strategies, and so on) above its supporting text. Previously only the supporting sentence was rendered and the section titles existed solely as CSS class names.
- **Trends** was audited and left alone: its chart cards already sit on surface containers with the 16px card radius and the #98/#103 theming.