### PR TITLE
Add haptic feedback

### DIFF
--- a/JournalApp/Components/DataPointView.razor
+++ b/JournalApp/Components/DataPointView.razor
@@ -4,6 +4,7 @@
 @inject IDialogService DialogService
 @inject ISnackbar Snackbar
 @inject DataPointService DataPointService
+@inject HapticFeedbackService HapticFeedback
 
 @if (Point.Type == PointType.Mood)
 {
@@ -24,7 +25,7 @@ else if (Point.Type == PointType.Scale)
 }
 else if (Point.Type == PointType.LowToHigh)
 {
-    <MudToggleGroup T="int?" @bind-Value="Point.ScaleIndex" SelectionMode="SelectionMode.ToggleSelection" Size="Size.Small" CheckMark>
+    <MudToggleGroup T="int?" @bind-Value="Point.ScaleIndex" @bind-Value:after="HapticFeedback.Tick" SelectionMode="SelectionMode.ToggleSelection" Size="Size.Small" CheckMark>
         <MudToggleItem T="int?" Value="0">None</MudToggleItem>
         <MudToggleItem T="int?" Value="1">Low</MudToggleItem>
         <MudToggleItem T="int?" Value="3">Medium</MudToggleItem>
@@ -33,7 +34,7 @@ else if (Point.Type == PointType.LowToHigh)
 }
 else if (Point.Type == PointType.MildToSevere)
 {
-    <MudToggleGroup T="int?" @bind-Value="Point.ScaleIndex" SelectionMode="SelectionMode.ToggleSelection" Size="Size.Small" CheckMark>
+    <MudToggleGroup T="int?" @bind-Value="Point.ScaleIndex" @bind-Value:after="HapticFeedback.Tick" SelectionMode="SelectionMode.ToggleSelection" Size="Size.Small" CheckMark>
         <MudToggleItem T="int?" Value="0">None</MudToggleItem>
         <MudToggleItem T="int?" Value="1">Mild</MudToggleItem>
         <MudToggleItem T="int?" Value="3">Moderate</MudToggleItem>
@@ -42,7 +43,7 @@ else if (Point.Type == PointType.MildToSevere)
 }
 else if (Point.Type == PointType.Bool)
 {
-    <MudToggleGroup T="bool?" @bind-Value="Point.Bool" SelectionMode="SelectionMode.ToggleSelection" Size="Size.Small" CheckMark>
+    <MudToggleGroup T="bool?" @bind-Value="Point.Bool" @bind-Value:after="OnBoolChanged" SelectionMode="SelectionMode.ToggleSelection" Size="Size.Small" CheckMark>
         <MudToggleItem T="bool?" Value="false">No</MudToggleItem>
         <MudToggleItem T="bool?" Value="true">Yes</MudToggleItem>
     </MudToggleGroup>
@@ -96,7 +97,11 @@ else if (Point.Type == PointType.Medication)
     public int ScaleIndexForMudRating
     {
         get => DataPointService.GetScaleIndex(Point);
-        set => DataPointService.SetScaleIndex(Point, value);
+        set
+        {
+            DataPointService.SetScaleIndex(Point, value);
+            HapticFeedback.Tick();
+        }
     }
 
     string NoteLabel
@@ -121,12 +126,22 @@ else if (Point.Type == PointType.Medication)
     {
         logger.LogDebug("Decrementing sleep");
         DataPointService.DecrementSleep(Point);
+        HapticFeedback.Tick();
     }
 
     void IncrementSleep()
     {
         logger.LogDebug("Incrementing sleep");
         DataPointService.IncrementSleep(Point);
+        HapticFeedback.Tick();
+    }
+
+    void OnBoolChanged()
+    {
+        if (Point.Bool == true)
+            HapticFeedback.ToggleOn();
+        else
+            HapticFeedback.ToggleOff();
     }
 
     async Task EditTextInDialog()
@@ -142,6 +157,11 @@ else if (Point.Type == PointType.Medication)
     {
         // Use service to handle medication dose reset logic
         DataPointService.HandleMedicationTakenChanged(Point);
+
+        if (Point.Bool == true)
+            HapticFeedback.ToggleOn();
+        else
+            HapticFeedback.ToggleOff();
 
         await StateChanged.InvokeAsync();
     }
@@ -159,6 +179,7 @@ else if (Point.Type == PointType.Medication)
     {
         logger.LogDebug("Mood selected: {mood}", mood);
         DataPointService.SetMood(Point, mood);
+        HapticFeedback.Tick();
 
         // Show a motivational quote when the sob emoji is selected
         if (mood == DataPoint.Moods[^1])  // Sob emoji (😭) is the last mood in the list

--- a/JournalApp/Components/DataPointView.razor
+++ b/JournalApp/Components/DataPointView.razor
@@ -15,7 +15,7 @@ else if (Point.Type == PointType.Sleep)
     <div class="sleep-controls">
         <MudText Class="sleep-hours" Typo="Typo.caption">@((Point.SleepHours ?? 0).ToString("0.0"))</MudText>
         <MudIconButton Class="less-sleep" Icon="@Icons.Material.Rounded.Remove" aria-label="Less sleep" OnClick="DecrementSleep" Disabled="@(Point.SleepHours <= 0)" Size="Size.Small" />
-        <MudSlider T="decimal" @bind-NullableValue="Point.SleepHours" Variant="Variant.Filled" Min="0" Max="24" Step="0.5m" />
+        <MudSlider T="decimal" NullableValue="Point.SleepHours" NullableValueChanged="SleepChanged" Variant="Variant.Filled" Min="0" Max="24" Step="0.5m" />
         <MudIconButton Class="more-sleep" Icon="@Icons.Material.Rounded.Add" aria-label="More sleep" OnClick="IncrementSleep" Disabled="@(Point.SleepHours >= 24)" Size="Size.Small" />
     </div>
 }
@@ -124,6 +124,13 @@ else if (Point.Type == PointType.Medication)
         logger.LogDebug("Incrementing sleep");
         DataPointService.IncrementSleep(Point);
         HapticFeedback.Tick();
+    }
+
+    void SleepChanged(decimal? value)
+    {
+        Point.SleepHours = value;
+        // Dragging crosses many half-hour steps in quick succession so use the soft frequent tick.
+        HapticFeedback.DragTick();
     }
 
     void ScaleValueChanged(int value)

--- a/JournalApp/Components/DataPointView.razor
+++ b/JournalApp/Components/DataPointView.razor
@@ -21,11 +21,11 @@ else if (Point.Type == PointType.Sleep)
 }
 else if (Point.Type == PointType.Scale)
 {
-    <MudRating @bind-SelectedValue="ScaleIndexForMudRating" FullIcon="@Icons.Material.Rounded.Circle" EmptyIcon="@Icons.Material.Rounded.Circle" Color="Color.Primary" />
+    <MudRating SelectedValue="DataPointService.GetScaleIndex(Point)" SelectedValueChanged="ScaleValueChanged" FullIcon="@Icons.Material.Rounded.Circle" EmptyIcon="@Icons.Material.Rounded.Circle" Color="Color.Primary" />
 }
 else if (Point.Type == PointType.LowToHigh)
 {
-    <MudToggleGroup T="int?" @bind-Value="Point.ScaleIndex" @bind-Value:after="HapticFeedback.Tick" SelectionMode="SelectionMode.ToggleSelection" Size="Size.Small" CheckMark>
+    <MudToggleGroup T="int?" Value="Point.ScaleIndex" ValueChanged="ScaleIndexChanged" SelectionMode="SelectionMode.ToggleSelection" Size="Size.Small" CheckMark>
         <MudToggleItem T="int?" Value="0">None</MudToggleItem>
         <MudToggleItem T="int?" Value="1">Low</MudToggleItem>
         <MudToggleItem T="int?" Value="3">Medium</MudToggleItem>
@@ -34,7 +34,7 @@ else if (Point.Type == PointType.LowToHigh)
 }
 else if (Point.Type == PointType.MildToSevere)
 {
-    <MudToggleGroup T="int?" @bind-Value="Point.ScaleIndex" @bind-Value:after="HapticFeedback.Tick" SelectionMode="SelectionMode.ToggleSelection" Size="Size.Small" CheckMark>
+    <MudToggleGroup T="int?" Value="Point.ScaleIndex" ValueChanged="ScaleIndexChanged" SelectionMode="SelectionMode.ToggleSelection" Size="Size.Small" CheckMark>
         <MudToggleItem T="int?" Value="0">None</MudToggleItem>
         <MudToggleItem T="int?" Value="1">Mild</MudToggleItem>
         <MudToggleItem T="int?" Value="3">Moderate</MudToggleItem>
@@ -43,7 +43,7 @@ else if (Point.Type == PointType.MildToSevere)
 }
 else if (Point.Type == PointType.Bool)
 {
-    <MudToggleGroup T="bool?" @bind-Value="Point.Bool" @bind-Value:after="OnBoolChanged" SelectionMode="SelectionMode.ToggleSelection" Size="Size.Small" CheckMark>
+    <MudToggleGroup T="bool?" Value="Point.Bool" ValueChanged="OnBoolChanged" SelectionMode="SelectionMode.ToggleSelection" Size="Size.Small" CheckMark>
         <MudToggleItem T="bool?" Value="false">No</MudToggleItem>
         <MudToggleItem T="bool?" Value="true">Yes</MudToggleItem>
     </MudToggleGroup>
@@ -75,7 +75,7 @@ else if (Point.Type == PointType.Note)
 else if (Point.Type == PointType.Medication)
 {
     <div class="medication-controls">
-        <MudToggleGroup T="bool?" @bind-Value="Point.Bool" @bind-Value:after="OnMedicationTakenChanged" SelectionMode="SelectionMode.ToggleSelection" Size="Size.Small" CheckMark>
+        <MudToggleGroup T="bool?" Value="Point.Bool" ValueChanged="OnMedicationTakenChanged" SelectionMode="SelectionMode.ToggleSelection" Size="Size.Small" CheckMark>
             <MudToggleItem T="bool?" Value="false">No</MudToggleItem>
             <MudToggleItem T="bool?" Value="true">Yes</MudToggleItem>
         </MudToggleGroup>
@@ -93,16 +93,6 @@ else if (Point.Type == PointType.Medication)
 
     [Parameter]
     public EventCallback StateChanged { get; set; }
-
-    public int ScaleIndexForMudRating
-    {
-        get => DataPointService.GetScaleIndex(Point);
-        set
-        {
-            DataPointService.SetScaleIndex(Point, value);
-            HapticFeedback.Tick();
-        }
-    }
 
     string NoteLabel
     {
@@ -136,9 +126,23 @@ else if (Point.Type == PointType.Medication)
         HapticFeedback.Tick();
     }
 
-    void OnBoolChanged()
+    void ScaleValueChanged(int value)
     {
-        if (Point.Bool == true)
+        DataPointService.SetScaleIndex(Point, value);
+        HapticFeedback.Tick();
+    }
+
+    void ScaleIndexChanged(int? value)
+    {
+        Point.ScaleIndex = value;
+        HapticFeedback.Tick();
+    }
+
+    void OnBoolChanged(bool? value)
+    {
+        Point.Bool = value;
+
+        if (value == true)
             HapticFeedback.ToggleOn();
         else
             HapticFeedback.ToggleOff();
@@ -153,12 +157,14 @@ else if (Point.Type == PointType.Medication)
         await StateChanged.InvokeAsync();
     }
 
-    async Task OnMedicationTakenChanged()
+    async Task OnMedicationTakenChanged(bool? value)
     {
+        Point.Bool = value;
+
         // Use service to handle medication dose reset logic
         DataPointService.HandleMedicationTakenChanged(Point);
 
-        if (Point.Bool == true)
+        if (value == true)
             HapticFeedback.ToggleOn();
         else
             HapticFeedback.ToggleOff();

--- a/JournalApp/Components/EditCategoryDialog.razor
+++ b/JournalApp/Components/EditCategoryDialog.razor
@@ -2,6 +2,7 @@
 @inject ILogger<EditCategoryDialog> logger
 @inject IDialogService DialogService
 @inject KeyEventService KeyEventService
+@inject HapticFeedbackService HapticFeedback
 
 <MudDialog Class="category-dialog" DefaultFocus="DefaultFocus.FirstChild" OnBackdropClick="Submit">
     <TitleContent>
@@ -121,6 +122,7 @@
 
         Category.Deleted = true;
         logger.LogDebug($"Deleted {Category}");
+        HapticFeedback.LongPress();
         KeyEventService.CloseDialog(MudDialog, Category);
     }
 
@@ -133,6 +135,7 @@
         if (!_form.IsValid)
         {
             logger.LogDebug("Form was not valid");
+            HapticFeedback.Reject();
 
             if (Category == null)
                 Cancel();
@@ -151,6 +154,7 @@
 
         logger.LogDebug($"Created new category <Name: {Category.Name}, Type: {Category.Type}>");
 
+        HapticFeedback.Confirm();
         KeyEventService.CloseDialog(MudDialog, Category);
         return true;
     }

--- a/JournalApp/Components/EditCategoryDialog.razor
+++ b/JournalApp/Components/EditCategoryDialog.razor
@@ -122,7 +122,7 @@
 
         Category.Deleted = true;
         logger.LogDebug($"Deleted {Category}");
-        HapticFeedback.LongPress();
+        HapticFeedback.Confirm();
         KeyEventService.CloseDialog(MudDialog, Category);
     }
 

--- a/JournalApp/Components/EditDoseDialog.razor
+++ b/JournalApp/Components/EditDoseDialog.razor
@@ -2,6 +2,7 @@
 @inject ILogger<EditDoseDialog> logger
 @inject IDialogService DialogService
 @inject KeyEventService KeyEventService
+@inject HapticFeedbackService HapticFeedback
 
 <MudDialog DefaultFocus="DefaultFocus.FirstChild" OnBackdropClick="Submit">
     <TitleContent>
@@ -84,6 +85,7 @@
             logger.LogDebug("Updating with new dose and marking as taken");
         }
 
+        HapticFeedback.Confirm();
         KeyEventService.CloseDialog(MudDialog, true);
     }
 

--- a/JournalApp/Components/EditNoteDialog.razor
+++ b/JournalApp/Components/EditNoteDialog.razor
@@ -2,6 +2,7 @@
 @inject ILogger<EditNoteDialog> logger
 @inject IDialogService DialogService
 @inject KeyEventService KeyEventService
+@inject HapticFeedbackService HapticFeedback
 
 <MudDialog DefaultFocus="DefaultFocus.FirstChild" OnBackdropClick="Submit">
     <TitleContent>
@@ -80,6 +81,7 @@
         else
         {
             logger.LogInformation("Submitting note");
+            HapticFeedback.Confirm();
         }
 
         KeyEventService.CloseDialog(MudDialog, true);

--- a/JournalApp/Components/EmojiPicker.razor
+++ b/JournalApp/Components/EmojiPicker.razor
@@ -1,6 +1,7 @@
 ﻿@namespace JournalApp
+@inject HapticFeedbackService HapticFeedback
 
-<EmojiButton OnClick="@(() => _isOpen = !_isOpen)"
+<EmojiButton OnClick="TogglePicker"
              AriaLabel="Choose emoji for day's mood">
     @(SelectedMood ?? DataPoint.Moods[0])
 </EmojiButton>
@@ -32,6 +33,14 @@
 
     [Parameter]
     public EventCallback<string> OnMoodSelected { get; set; }
+
+    private void TogglePicker()
+    {
+        _isOpen = !_isOpen;
+
+        if (_isOpen)
+            HapticFeedback.Click();
+    }
 
     private async Task OnMoodClicked(string mood)
     {

--- a/JournalApp/Components/EmojiPicker.razor
+++ b/JournalApp/Components/EmojiPicker.razor
@@ -1,5 +1,4 @@
 ﻿@namespace JournalApp
-@inject HapticFeedbackService HapticFeedback
 
 <EmojiButton OnClick="TogglePicker"
              AriaLabel="Choose emoji for day's mood">
@@ -37,9 +36,6 @@
     private void TogglePicker()
     {
         _isOpen = !_isOpen;
-
-        if (_isOpen)
-            HapticFeedback.Click();
     }
 
     private async Task OnMoodClicked(string mood)

--- a/JournalApp/Data/CommonServices.cs
+++ b/JournalApp/Data/CommonServices.cs
@@ -22,6 +22,7 @@ public static class CommonServices
 
         services.AddSingleton<AppDataService>();
         services.AddSingleton<AppDbSeeder>();
+        services.AddSingleton<HapticFeedbackService>();
         services.AddSingleton<KeyEventService>();
         services.AddSingleton<PreferenceService>();
         services.AddSingleton<CalendarService>();

--- a/JournalApp/Data/HapticFeedbackService.cs
+++ b/JournalApp/Data/HapticFeedbackService.cs
@@ -1,0 +1,85 @@
+namespace JournalApp;
+
+/// <summary>
+/// Plays semantic haptic cues for key interactions.
+/// On Android this goes through the decor view's PerformHapticFeedback, which needs no VIBRATE permission and respects the system touch feedback setting; elsewhere it's a no-op.
+/// </summary>
+public sealed class HapticFeedbackService
+{
+    /// <summary>
+    /// A light tap for opening a picker or similar minor interaction.
+    /// </summary>
+    public void Click()
+    {
+#if ANDROID
+        Perform(Android.Views.FeedbackConstants.VirtualKey);
+#endif
+    }
+
+    /// <summary>
+    /// A heavy buzz for destructive actions like a permanent delete.
+    /// </summary>
+    public void LongPress()
+    {
+#if ANDROID
+        Perform(Android.Views.FeedbackConstants.LongPress);
+#endif
+    }
+
+    /// <summary>
+    /// Signals an action completed successfully, like submitting a dialog.
+    /// </summary>
+    public void Confirm()
+    {
+#if ANDROID
+        // Confirm/Reject exist since API 30.
+        Perform(OperatingSystem.IsAndroidVersionAtLeast(30) ? Android.Views.FeedbackConstants.Confirm : Android.Views.FeedbackConstants.KeyboardTap);
+#endif
+    }
+
+    /// <summary>
+    /// Signals an action was denied, like failing validation.
+    /// </summary>
+    public void Reject()
+    {
+#if ANDROID
+        Perform(OperatingSystem.IsAndroidVersionAtLeast(30) ? Android.Views.FeedbackConstants.Reject : Android.Views.FeedbackConstants.LongPress);
+#endif
+    }
+
+    /// <summary>
+    /// A switch or binary choice turning on.
+    /// </summary>
+    public void ToggleOn()
+    {
+#if ANDROID
+        // ToggleOn/ToggleOff and SegmentTick exist since API 34.
+        Perform(OperatingSystem.IsAndroidVersionAtLeast(34) ? Android.Views.FeedbackConstants.ToggleOn : Android.Views.FeedbackConstants.ClockTick);
+#endif
+    }
+
+    /// <summary>
+    /// A switch or binary choice turning off.
+    /// </summary>
+    public void ToggleOff()
+    {
+#if ANDROID
+        Perform(OperatingSystem.IsAndroidVersionAtLeast(34) ? Android.Views.FeedbackConstants.ToggleOff : Android.Views.FeedbackConstants.ClockTick);
+#endif
+    }
+
+    /// <summary>
+    /// A discrete step through segmented values, like picking a mood or nudging sleep hours.
+    /// </summary>
+    public void Tick()
+    {
+#if ANDROID
+        Perform(OperatingSystem.IsAndroidVersionAtLeast(34) ? Android.Views.FeedbackConstants.SegmentTick : Android.Views.FeedbackConstants.ClockTick);
+#endif
+    }
+
+#if ANDROID
+    private static void Perform(Android.Views.FeedbackConstants constant) =>
+        Platform.CurrentActivity?.Window?.DecorView?.PerformHapticFeedback(constant);
+#endif
+}

--- a/JournalApp/Data/HapticFeedbackService.cs
+++ b/JournalApp/Data/HapticFeedbackService.cs
@@ -7,16 +7,6 @@ namespace JournalApp;
 public sealed class HapticFeedbackService
 {
     /// <summary>
-    /// A light tap for opening a picker or similar minor interaction.
-    /// </summary>
-    public void Click()
-    {
-#if ANDROID
-        Perform(Android.Views.FeedbackConstants.VirtualKey);
-#endif
-    }
-
-    /// <summary>
     /// A heavy buzz for destructive actions like a permanent delete.
     /// </summary>
     public void LongPress()
@@ -75,6 +65,17 @@ public sealed class HapticFeedbackService
     {
 #if ANDROID
         Perform(OperatingSystem.IsAndroidVersionAtLeast(34) ? Android.Views.FeedbackConstants.SegmentTick : Android.Views.FeedbackConstants.ClockTick);
+#endif
+    }
+
+    /// <summary>
+    /// A very soft tick for continuously dragging through many values, like a slider.
+    /// </summary>
+    public void DragTick()
+    {
+#if ANDROID
+        // SegmentFrequentTick exists since API 34 and stays soft when fired rapidly during a drag.
+        Perform(OperatingSystem.IsAndroidVersionAtLeast(34) ? Android.Views.FeedbackConstants.SegmentFrequentTick : Android.Views.FeedbackConstants.ClockTick);
 #endif
     }
 

--- a/JournalApp/Data/HapticFeedbackService.cs
+++ b/JournalApp/Data/HapticFeedbackService.cs
@@ -7,16 +7,6 @@ namespace JournalApp;
 public sealed class HapticFeedbackService
 {
     /// <summary>
-    /// A heavy buzz for destructive actions like a permanent delete.
-    /// </summary>
-    public void LongPress()
-    {
-#if ANDROID
-        Perform(Android.Views.FeedbackConstants.LongPress);
-#endif
-    }
-
-    /// <summary>
     /// Signals an action completed successfully, like submitting a dialog.
     /// </summary>
     public void Confirm()

--- a/JournalApp/Pages/ManageCategoriesPage.razor
+++ b/JournalApp/Pages/ManageCategoriesPage.razor
@@ -4,6 +4,7 @@
 @implements IDisposable
 @inject ILogger<ManageCategoriesPage> logger
 @inject IDbContextFactory<AppDbContext> DbFactory
+@inject HapticFeedbackService HapticFeedback
 
 <header class="page-header">
     <div class="page-toolbar">
@@ -74,6 +75,12 @@
     {
         logger.LogInformation($"Toggled category enabled <{c}, {newValue}>");
         c.Enabled = newValue;
+
+        if (newValue)
+            HapticFeedback.ToggleOn();
+        else
+            HapticFeedback.ToggleOff();
+
         await db.SaveChangesAsync();
     }
 

--- a/JournalApp/Pages/SettingsPage.razor
+++ b/JournalApp/Pages/SettingsPage.razor
@@ -5,6 +5,7 @@
 @inject ILogger<SettingsPage> logger
 @inject AppDataUIService AppDataUIService
 @inject IFilePicker FilePicker
+@inject HapticFeedbackService HapticFeedback
 
 @if (_busy)
 {
@@ -32,7 +33,7 @@ else
                     <div class="settings-item">
                         <MudText Class="settings-item-title">Theme</MudText>
 
-                        <MudToggleGroup T="AppTheme" Value="PreferenceService.SelectedAppTheme" ValueChanged="v => PreferenceService.SelectedAppTheme = v" SelectionMode="SelectionMode.SingleSelection" Size="Size.Small" CheckMark aria-label="Theme for entire app">
+                        <MudToggleGroup T="AppTheme" Value="PreferenceService.SelectedAppTheme" ValueChanged="SelectedAppThemeChanged" SelectionMode="SelectionMode.SingleSelection" Size="Size.Small" CheckMark aria-label="Theme for entire app">
                             <MudToggleItem T="AppTheme" Value="@(AppTheme.Light)">Light</MudToggleItem>
                             <MudToggleItem T="AppTheme" Value="@(AppTheme.Dark)">Dark</MudToggleItem>
                             <MudToggleItem T="AppTheme" Value="@(AppTheme.Unspecified)">System</MudToggleItem>
@@ -40,12 +41,12 @@ else
                     </div>
 
                     <div class="settings-item">
-                        <MudSwitch T="bool" Value="PreferenceService.SupportsDeviceColors && PreferenceService.UseDeviceColors" ValueChanged="v => PreferenceService.UseDeviceColors = v"
+                        <MudSwitch T="bool" Value="PreferenceService.SupportsDeviceColors && PreferenceService.UseDeviceColors" ValueChanged="UseDeviceColorsChanged"
                                    Disabled="!PreferenceService.SupportsDeviceColors" Color="Color.Primary" aria-label="Color the app from your device wallpaper">Use device colors</MudSwitch>
                     </div>
 
                     <div class="settings-item">
-                        <MudSwitch @bind-Value="PreferenceService.HideNotes" Color="Color.Primary" aria-label="Hide the notes section on the home page">Hide "Today's notes"</MudSwitch>
+                        <MudSwitch @bind-Value="PreferenceService.HideNotes" @bind-Value:after="HideNotesChanged" Color="Color.Primary" aria-label="Hide the notes section on the home page">Hide "Today's notes"</MudSwitch>
                     </div>
                 </div>
             </section>
@@ -151,6 +152,25 @@ else
     void SelectedAppThemeChanged(AppTheme newTheme)
     {
         PreferenceService.SelectedAppTheme = newTheme;
+        HapticFeedback.Tick();
+    }
+
+    void UseDeviceColorsChanged(bool newValue)
+    {
+        PreferenceService.UseDeviceColors = newValue;
+
+        if (newValue)
+            HapticFeedback.ToggleOn();
+        else
+            HapticFeedback.ToggleOff();
+    }
+
+    void HideNotesChanged()
+    {
+        if (PreferenceService.HideNotes)
+            HapticFeedback.ToggleOn();
+        else
+            HapticFeedback.ToggleOff();
     }
 
     void SetUpSafetyPlan()

--- a/JournalApp/Pages/SettingsPage.razor
+++ b/JournalApp/Pages/SettingsPage.razor
@@ -46,7 +46,7 @@ else
                     </div>
 
                     <div class="settings-item">
-                        <MudSwitch @bind-Value="PreferenceService.HideNotes" @bind-Value:after="HideNotesChanged" Color="Color.Primary" aria-label="Hide the notes section on the home page">Hide "Today's notes"</MudSwitch>
+                        <MudSwitch T="bool" Value="PreferenceService.HideNotes" ValueChanged="HideNotesChanged" Color="Color.Primary" aria-label="Hide the notes section on the home page">Hide "Today's notes"</MudSwitch>
                     </div>
                 </div>
             </section>
@@ -165,9 +165,11 @@ else
             HapticFeedback.ToggleOff();
     }
 
-    void HideNotesChanged()
+    void HideNotesChanged(bool newValue)
     {
-        if (PreferenceService.HideNotes)
+        PreferenceService.HideNotes = newValue;
+
+        if (newValue)
             HapticFeedback.ToggleOn();
         else
             HapticFeedback.ToggleOff();


### PR DESCRIPTION
A small haptics service (`Data/HapticFeedbackService.cs`) that plays predefined Android `HapticFeedbackConstants` on discrete, meaningful interactions. Singleton, shared with the tests, no-op off Android.

Where it fires:
- Ticks on the mood, rating, and low/high and mild/severe pickers, and the sleep steppers. The sleep slider uses the softer frequent tick since dragging crosses a lot of steps at once.
- Toggle on/off on the yes/no, medication, and settings switches.
- Confirm on submitting a note, category, or dose, and on deleting a category; reject when a category fails validation.

Nothing on scrolling, typing (the keyboard handles its own), or plain navigation.

It goes through `View.PerformHapticFeedback`, so no `VIBRATE` permission and it honors the system touch-feedback setting. The API 30/34 constants fall back to older ones down to our min SDK of 27. Controls hook `ValueChanged` instead of `@bind-Value:after` to keep logic out of setters.
