### PR TITLE
Make dialogs look more like M3

### DIFF
--- a/JournalApp/Components/EditCategoryDialog.razor
+++ b/JournalApp/Components/EditCategoryDialog.razor
@@ -52,12 +52,14 @@
     <DialogActions>
         @if (Category != null)
         {
-            <MudButton Class="delete-button" StartIcon="@Icons.Material.Rounded.DeleteForever" OnClick="Delete" Color="Color.Error">Delete</MudButton>
+            <MudButton Class="delete-button" OnClick="Delete" Color="Color.Error">Delete</MudButton>
+
+            <MudSpacer />
         }
 
-        <MudButton Class="cancel-button" StartIcon="@Icons.Material.Rounded.Close" OnClick="Cancel">Cancel</MudButton>
+        <MudButton Class="cancel-button" OnClick="Cancel" Color="Color.Primary">Cancel</MudButton>
 
-        <MudButton Class="submit-button" StartIcon="@Icons.Material.Rounded.Check" OnClick="Submit" Variant="Variant.Filled" Color="Color.Primary">Submit</MudButton>
+        <MudButton Class="submit-button" OnClick="Submit" Color="Color.Primary">Submit</MudButton>
     </DialogActions>
 </MudDialog>
 

--- a/JournalApp/Components/EditDoseDialog.razor
+++ b/JournalApp/Components/EditDoseDialog.razor
@@ -24,9 +24,9 @@
     </DialogContent>
 
     <DialogActions>
-        <MudButton Class="cancel-button" StartIcon="@Icons.Material.Rounded.Close" OnClick="Cancel">Cancel</MudButton>
+        <MudButton Class="cancel-button" OnClick="Cancel" Color="Color.Primary">Cancel</MudButton>
 
-        <MudButton Class="submit-button" StartIcon="@Icons.Material.Rounded.Check" OnClick="Submit" Variant="Variant.Filled" Color="Color.Primary">Submit</MudButton>
+        <MudButton Class="submit-button" OnClick="Submit" Color="Color.Primary">Submit</MudButton>
     </DialogActions>
 </MudDialog>
 

--- a/JournalApp/Components/EditNoteDialog.razor
+++ b/JournalApp/Components/EditNoteDialog.razor
@@ -13,9 +13,9 @@
     </DialogContent>
 
     <DialogActions>
-        <MudButton Class="cancel-button" StartIcon="@Icons.Material.Rounded.Close" OnClick="Cancel">Cancel</MudButton>
+        <MudButton Class="cancel-button" OnClick="Cancel" Color="Color.Primary">Cancel</MudButton>
 
-        <MudButton Class="submit-button" StartIcon="@Icons.Material.Rounded.Check" OnClick="Submit" Variant="Variant.Filled" Color="Color.Primary">Submit</MudButton>
+        <MudButton Class="submit-button" OnClick="Submit" Color="Color.Primary">Submit</MudButton>
     </DialogActions>
 </MudDialog>
 

--- a/JournalApp/Components/JaMessageBox.razor
+++ b/JournalApp/Components/JaMessageBox.razor
@@ -41,7 +41,7 @@
                 }
                 else if (!string.IsNullOrWhiteSpace(CancelText))
                 {
-                    <MudButton Class="mud-message-box__cancel-button" OnClick="OnCancelClicked">@CancelText</MudButton>
+                    <MudButton Class="mud-message-box__cancel-button" OnClick="OnCancelClicked" Color="Color.Primary">@CancelText</MudButton>
                 }
                 @if (NoButton is not null)
                 {
@@ -51,7 +51,7 @@
                 }
                 else if (!string.IsNullOrWhiteSpace(NoText))
                 {
-                    <MudButton Class="mud-message-box__no-button" OnClick="OnNoClicked">@NoText</MudButton>
+                    <MudButton Class="mud-message-box__no-button" OnClick="OnNoClicked" Color="Color.Primary">@NoText</MudButton>
                 }
                 @if (YesButton is not null)
                 {
@@ -61,7 +61,7 @@
                 }
                 else if (!string.IsNullOrWhiteSpace(YesText))
                 {
-                    <MudButton Class="mud-message-box__yes-button" OnClick="OnYesClicked" Variant="Variant.Filled" Color="Color.Primary">@YesText</MudButton>
+                    <MudButton Class="mud-message-box__yes-button" OnClick="OnYesClicked" Color="Color.Primary">@YesText</MudButton>
                 }
             </MudFocusTrap>
         </div>

--- a/JournalApp/wwwroot/app.css
+++ b/JournalApp/wwwroot/app.css
@@ -269,12 +269,36 @@ label.mud-switch.mud-disabled .mud-switch-span {
   --mud-palette-surface: var(--mud-palette-gray-lighter);
 }
 
-/* M3 dialogs sit on surfaceContainerHigh. */
+/* M3 dialogs sit on surfaceContainerHigh with the 24px container inset. */
 .mud-dialog {
-  padding: 12px !important;
-  gap: 12px !important;
+  padding: 24px !important;
+  gap: 16px !important;
   border-radius: 28px;
   --mud-palette-surface: var(--mud-palette-gray-lighter);
+}
+
+/* M3 dialog headline is headline-small on the leading edge, not a centered bold h6. */
+.mud-dialog-title {
+  padding: 0 !important;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+}
+
+.mud-dialog-title .mud-typography-h6 {
+  font-size: 24px;
+  font-weight: 400;
+  line-height: 32px;
+}
+
+/* M3 dialog supporting text reads on onSurfaceVariant; inputs keep their own stronger ink. */
+.mud-dialog-content {
+  color: var(--mud-palette-text-secondary);
+}
+
+.mud-dialog-actions {
+  gap: 8px;
+  justify-content: flex-end;
 }
 
 /* M3 filled cards: tonal, flat (depth comes from tone, not shadow). */
@@ -290,7 +314,7 @@ label.mud-switch.mud-disabled .mud-switch-span {
   font-size: inherit;
 }
 
-.mud-dialog-title, .mud-card-header {
+.mud-card-header {
   padding: 0 !important;
   padding-top: 8px !important;
   display: flex;


### PR DESCRIPTION
All four dialog components (note editor, category editor, dose editor, message boxes) now follow the M3 basic dialog spec:

- Headline-small titles on the leading edge instead of a centered bold h6.
- The 24px container inset with 16px section spacing.
- Supporting text on onSurfaceVariant, with inputs keeping their stronger ink.
- Right-aligned primary text buttons with no leading icons, replacing the filled Submit pill. The category editor keeps Delete on the leading edge with a spacer, per the M3 destructive-action placement.
