### PR TITLE
One Material 3 Expressive shape, color and motion system

### DIFF
--- a/JournalApp.Tests/Data/PreferenceServiceTests.cs
+++ b/JournalApp.Tests/Data/PreferenceServiceTests.cs
@@ -44,6 +44,37 @@ public class PreferenceServiceTests : JaTestContext
     }
 
     [Fact]
+    public void HandleOsThemeChanged_KeepsTheUsersChoice()
+    {
+        // Arrange
+        var preferences = Services.GetService<IPreferences>();
+        var preferenceService = Services.GetService<PreferenceService>();
+        preferenceService.SelectedAppTheme = AppTheme.Light;
+
+        // Act
+        preferenceService.HandleOsThemeChanged();
+
+        // Assert
+        preferenceService.SelectedAppTheme.Should().Be(AppTheme.Light);
+        preferences.Get("theme", string.Empty).Should().Be(nameof(AppTheme.Light));
+    }
+
+    [Fact]
+    public void HandleOsThemeChanged_RaisesThemeChanged()
+    {
+        // Arrange
+        var preferenceService = Services.GetService<PreferenceService>();
+        var raised = 0;
+        preferenceService.ThemeChanged += (_, _) => raised++;
+
+        // Act
+        preferenceService.HandleOsThemeChanged();
+
+        // Assert
+        raised.Should().Be(1);
+    }
+
+    [Fact]
     public void SafetyPlan_WithMalformedJson_ReturnsNull()
     {
         // Arrange

--- a/JournalApp.Tests/MaterialThemeTests.cs
+++ b/JournalApp.Tests/MaterialThemeTests.cs
@@ -16,6 +16,8 @@ public class MaterialThemeTests
         Hex(theme.PaletteLight.PrimaryLighten).Should().Be("#FFD8EE");
         Hex(theme.PaletteLight.PrimaryDarken).Should().Be("#69345A");
         Hex(theme.PaletteLight.Secondary).Should().Be("#705766");
+        Hex(theme.PaletteLight.SecondaryLighten).Should().Be("#FADAEB");
+        Hex(theme.PaletteLight.SecondaryDarken).Should().Be("#57404E");
         Hex(theme.PaletteLight.Tertiary).Should().Be("#81533F");
         Hex(theme.PaletteLight.Error).Should().Be("#BA1A1A");
         Hex(theme.PaletteLight.Info).Should().Be("#1A59C2");
@@ -38,6 +40,8 @@ public class MaterialThemeTests
         Hex(theme.PaletteDark.PrimaryLighten).Should().Be("#69345A");
         Hex(theme.PaletteDark.PrimaryDarken).Should().Be("#FFD8EE");
         Hex(theme.PaletteDark.Secondary).Should().Be("#DDBECF");
+        Hex(theme.PaletteDark.SecondaryLighten).Should().Be("#57404E");
+        Hex(theme.PaletteDark.SecondaryDarken).Should().Be("#FADAEB");
         Hex(theme.PaletteDark.Tertiary).Should().Be("#F4B9A0");
         Hex(theme.PaletteDark.Error).Should().Be("#FFB4AB");
         Hex(theme.PaletteDark.Info).Should().Be("#B0C6FF");
@@ -63,5 +67,50 @@ public class MaterialThemeTests
 
         Hex(blue.PaletteLight.Primary).Should().NotBe("#844C72");
         Hex(blue.PaletteLight.Background).Should().NotBe(Hex(blue.PaletteLight.Surface), "the surface container ladder should keep distinct tones");
+    }
+
+    [Fact]
+    public void ToggleSegmentPairsStayLegibleForAnySeed()
+    {
+        // Light mode surfaces are only ~1.05:1 apart, so the toggle group leans on chroma and on a filled primary selection instead of tone.
+        // These are the pairs app.css actually draws, and every one of them has to clear the M3 4.5:1 text floor whatever seed the device supplies.
+        foreach (var seed in new uint[] { MaterialTheme.DefaultSeed, 0xFF4285F4, 0xFF4CAF50, 0xFFFF9800, 0xFF000000, 0xFFFFFFFF })
+        {
+            var theme = MaterialTheme.FromSeed(seed);
+
+            foreach (var palette in new Palette[] { theme.PaletteLight, theme.PaletteDark })
+            {
+                Contrast(palette.SecondaryDarken, palette.SecondaryLighten).Should()
+                    .BeGreaterThan(4.5, $"an unselected segment label must read on its tonal fill (seed {seed:X8})");
+
+                Contrast(palette.PrimaryContrastText, palette.Primary).Should()
+                    .BeGreaterThan(4.5, $"a selected segment label must read on the filled primary pill (seed {seed:X8})");
+
+                Contrast(palette.Primary, palette.SecondaryLighten).Should()
+                    .BeGreaterThan(3, $"the selected segment must separate from its unselected neighbours (seed {seed:X8})");
+
+                Contrast(palette.Primary, palette.Surface).Should()
+                    .BeGreaterThan(3, $"the selected segment must separate from the row it sits on (seed {seed:X8})");
+            }
+        }
+    }
+
+    private static double Contrast(MudColor a, MudColor b)
+    {
+        var la = RelativeLuminance(a);
+        var lb = RelativeLuminance(b);
+
+        return la > lb ? (la + 0.05) / (lb + 0.05) : (lb + 0.05) / (la + 0.05);
+    }
+
+    private static double RelativeLuminance(MudColor color)
+    {
+        static double Channel(byte value)
+        {
+            var srgb = value / 255.0;
+            return srgb <= 0.03928 ? srgb / 12.92 : Math.Pow((srgb + 0.055) / 1.055, 2.4);
+        }
+
+        return (0.2126 * Channel(color.R)) + (0.7152 * Channel(color.G)) + (0.0722 * Channel(color.B));
     }
 }

--- a/JournalApp/Components/DataPointView.razor
+++ b/JournalApp/Components/DataPointView.razor
@@ -21,7 +21,8 @@ else if (Point.Type == PointType.Sleep)
 }
 else if (Point.Type == PointType.Scale)
 {
-    <MudRating SelectedValue="DataPointService.GetScaleIndex(Point)" SelectedValueChanged="ScaleValueChanged" FullIcon="@Icons.Material.Rounded.Circle" EmptyIcon="@Icons.Material.Rounded.Circle" Color="Color.Primary" />
+    @* A filled and an outlined dot, because MudRating paints both icons in the same color and two filled circles would look identical. *@
+    <MudRating SelectedValue="DataPointService.GetScaleIndex(Point)" SelectedValueChanged="ScaleValueChanged" FullIcon="@Icons.Material.Rounded.Circle" EmptyIcon="@Icons.Material.Rounded.RadioButtonUnchecked" Color="Color.Primary" />
 }
 else if (Point.Type == PointType.LowToHigh)
 {

--- a/JournalApp/Components/JaMessageBox.razor
+++ b/JournalApp/Components/JaMessageBox.razor
@@ -3,13 +3,13 @@
 
 <MudDialog @attributes="UserAttributes" Class="@Classname" OnBackdropClick="OnBackdropClick">
     <TitleContent>
-        @if (TitleContent is null)
-        {
-            <MudText Typo="Typo.h6">@Title</MudText>
-        }
-        else
+        @if (TitleContent is not null)
         {
             @TitleContent
+        }
+        else if (!string.IsNullOrWhiteSpace(Title))
+        {
+            <MudText Typo="Typo.h6">@Title</MudText>
         }
     </TitleContent>
     <DialogContent>

--- a/JournalApp/Data/MaterialTheme.cs
+++ b/JournalApp/Data/MaterialTheme.cs
@@ -59,15 +59,15 @@ public static class MaterialTheme
                 Info = Hex(info[40]),
                 InfoContrastText = "#FFFFFF",
                 InfoLighten = Hex(info[90]),
-                InfoDarken = Hex(info[10]),
+                InfoDarken = Hex(info[30]),
                 Success = Hex(success[40]),
                 SuccessContrastText = "#FFFFFF",
                 SuccessLighten = Hex(success[90]),
-                SuccessDarken = Hex(success[10]),
+                SuccessDarken = Hex(success[30]),
                 Warning = Hex(warning[40]),
                 WarningContrastText = "#FFFFFF",
                 WarningLighten = Hex(warning[90]),
-                WarningDarken = Hex(warning[10]),
+                WarningDarken = Hex(warning[30]),
                 Background = Hex(neutral[98]),
                 BackgroundGray = Hex(neutral[96]),
                 Surface = Hex(neutral[94]),
@@ -84,6 +84,9 @@ public static class MaterialTheme
                 TableLines = Hex(neutralVariant[80]),
                 Dark = Hex(neutral[20]),
                 DarkContrastText = Hex(neutral[95]),
+
+                // M3 scrim is the neutral black at 32%; MudBlazor's default is a grey that lightens the page in dark mode.
+                OverlayDark = "rgba(0,0,0,0.32)",
 
                 HoverOpacity = 0.08,
             },
@@ -135,16 +138,26 @@ public static class MaterialTheme
                 Dark = Hex(neutral[90]),
                 DarkContrastText = Hex(neutral[20]),
 
+                // M3 scrim is the neutral black at 32%; MudBlazor's default is a grey that lightens the page in dark mode.
+                OverlayDark = "rgba(0,0,0,0.32)",
+
                 HoverOpacity = 0.08,
             },
 
             LayoutProperties = new()
             {
-                DefaultBorderRadius = "8px",
+                // The M3 medium corner, so anything not styled by hand still lands on a real shape token.
+                DefaultBorderRadius = "12px",
             },
 
             Typography = new()
             {
+                Default = new DefaultTypography()
+                {
+                    // The device's own UI font is what makes a WebView app read as native; Roboto is the Android fallback.
+                    FontFamily = ["system-ui", "Roboto", "Helvetica", "Arial", "sans-serif"],
+                },
+
                 Button = new ButtonTypography()
                 {
                     TextTransform = "none",

--- a/JournalApp/Data/PreferenceService.cs
+++ b/JournalApp/Data/PreferenceService.cs
@@ -52,7 +52,7 @@ public sealed partial class PreferenceService : IPreferences, IDisposable
             _application.RequestedThemeChanged += Application_RequestedThemeChanged;
         }
 
-        UpdateStatusBar();
+        ApplyPlatformTheme();
     }
 
     public AppTheme SelectedAppTheme
@@ -181,26 +181,44 @@ public sealed partial class PreferenceService : IPreferences, IDisposable
 
     public event EventHandler<bool> ThemeChanged;
 
-    private void Application_RequestedThemeChanged(object sender, AppThemeChangedEventArgs e)
-    {
-        _theme = e.RequestedTheme;
-        OnThemeChanged();
-    }
+    private void Application_RequestedThemeChanged(object sender, AppThemeChangedEventArgs e) => HandleOsThemeChanged();
+
+    /// <summary>
+    /// Repaints for an OS theme change without touching the theme the user picked, which stays whatever they chose including System.
+    /// </summary>
+    internal void HandleOsThemeChanged() => OnThemeChanged();
 
     private void OnThemeChanged()
     {
-        UpdateStatusBar();
+        ApplyPlatformTheme();
         ThemeChanged?.Invoke(this, IsDarkMode);
     }
 
-    private void UpdateStatusBar()
+    /// <summary>
+    /// Pushes the active theme out to the native chrome that the web layer can't reach.
+    /// </summary>
+    public void ApplyPlatformTheme()
     {
+        if (_application == null)
+            return;
+
+        logger.LogDebug("Applying platform theme");
+
+        // The window's appearance drives the native resources the WebView sits inside, so it follows the in-app choice rather than only the OS.
+        if (_application.UserAppTheme != SelectedAppTheme)
+            _application.UserAppTheme = SelectedAppTheme;
+
+        var surface = IsDarkMode ? GetTheme().PaletteDark.Background : GetTheme().PaletteLight.Background;
+        var background = Color.FromRgb(surface.R, surface.G, surface.B);
+
+        // On Android 15 and up the system bars are transparent, so what shows behind them is this page background rather than any status bar color we set.
+        if (_application.Windows.Count > 0 && _application.Windows[0].Page is ContentPage page)
+            page.BackgroundColor = background;
+
         if (OperatingSystem.IsAndroid())
         {
-            logger.LogDebug("Updating status bar");
-            // Match the M3 surface tone so the status bar blends into the page header.
-            var surface = IsDarkMode ? GetTheme().PaletteDark.Background : GetTheme().PaletteLight.Background;
-            StatusBar.SetColor(Color.FromRgb(surface.R, surface.G, surface.B));
+            // Still needed below Android 15, where the status bar has its own color instead of showing the page through.
+            StatusBar.SetColor(background);
             StatusBar.SetStyle(IsDarkMode ? StatusBarStyle.LightContent : StatusBarStyle.DarkContent);
         }
     }

--- a/JournalApp/MainPage.xaml
+++ b/JournalApp/MainPage.xaml
@@ -5,6 +5,7 @@
              x:Class="JournalApp.MainPage"
              SafeAreaEdges="Container"
              BackgroundColor="{AppThemeBinding Light=#FFF8F9, Dark=#181215}">
+    <!-- The background is a first-frame default only; PreferenceService.ApplyPlatformTheme repaints it from the generated palette so device colors reach the letterbox too. -->
 
     <BlazorWebView HostPage="wwwroot/index.html" BlazorWebViewInitialized="OnBlazorWebViewInitialized">
         <BlazorWebView.RootComponents>

--- a/JournalApp/Pages/Calendar/CalendarDay.razor.css
+++ b/JournalApp/Pages/Calendar/CalendarDay.razor.css
@@ -9,11 +9,14 @@
   color: var(--mud-palette-text-primary);
 }
 
+/* Large bold type keeps the day number legible on the deepest mood fills, where the dark ramp only reaches 3.5:1 against the theme ink. */
 .calendar-day-number {
   position: absolute;
   top: 0;
   left: 0;
-  font-weight: bold;
+  font-size: 20px;
+  line-height: 1;
+  font-weight: 700;
 }
 
 .calendar-day-emoji {

--- a/JournalApp/Pages/Calendar/CalendarDay.razor.css
+++ b/JournalApp/Pages/Calendar/CalendarDay.razor.css
@@ -9,14 +9,11 @@
   color: var(--mud-palette-text-primary);
 }
 
-/* Large bold type keeps the day number legible on the deepest mood fills, where the dark ramp only reaches 3.5:1 against the theme ink. */
 .calendar-day-number {
   position: absolute;
   top: 0;
   left: 0;
-  font-size: 20px;
-  line-height: 1;
-  font-weight: 700;
+  font-weight: bold;
 }
 
 .calendar-day-emoji {

--- a/JournalApp/Pages/Calendar/CalendarMonth.razor.css
+++ b/JournalApp/Pages/Calendar/CalendarMonth.razor.css
@@ -5,10 +5,13 @@
   padding-top: 16px;
 }
 
+/* The month grid is a group container like every other list group: flat, tonal, large radius. */
 ::deep .calendar-month-grid {
   display: flex;
   flex-direction: column;
-  padding: 0;
+  padding: 4px;
+  border-radius: var(--ja-shape-lg-increased);
+  box-shadow: none;
 }
 
 ::deep .calendar-day-cell {
@@ -18,12 +21,25 @@
   padding: 1%;
   min-width: 32px;
   max-width: 96px;
-  border-radius: 8px;
-  transition: transform 0.1s ease-out;
+  border-radius: var(--ja-shape-md);
+  transition: transform var(--ja-motion-spatial);
 }
 
 ::deep .calendar-day-cell:has(:not(.calendar-day-empty)):active {
   transform: scale(0.95);
+}
+
+/* M3 calendar weekday labels are label-medium on onSurfaceVariant, not bold body text. */
+::deep .calendar-day-header {
+  justify-content: center;
+  color: var(--mud-palette-text-secondary);
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.5px;
+}
+
+::deep .calendar-day-header b {
+  font-weight: 500;
 }
 
 /* M3 marks today with a solid primary ring instead of a dashed generic outline. */

--- a/JournalApp/Pages/ManageCategoriesPage.razor.css
+++ b/JournalApp/Pages/ManageCategoriesPage.razor.css
@@ -2,7 +2,7 @@
 .manage-list {
   display: flex;
   flex-direction: column;
-  gap: 3px;
+  gap: 4px;
 }
 
 .manage-category {
@@ -11,18 +11,18 @@
   align-items: center;
   gap: 4px;
   background-color: var(--mud-palette-surface);
-  border-radius: 6px;
+  border-radius: var(--ja-shape-sm);
   padding: 6px 14px 6px 6px;
 }
 
 .manage-category:first-child {
-  border-top-left-radius: 18px;
-  border-top-right-radius: 18px;
+  border-top-left-radius: var(--ja-shape-lg-increased);
+  border-top-right-radius: var(--ja-shape-lg-increased);
 }
 
 .manage-category:last-child {
-  border-bottom-left-radius: 18px;
-  border-bottom-right-radius: 18px;
+  border-bottom-left-radius: var(--ja-shape-lg-increased);
+  border-bottom-right-radius: var(--ja-shape-lg-increased);
 }
 
 ::deep .manage-category-edit-button {

--- a/JournalApp/Pages/SafetyPlanning/SafetyPlanPage.razor.css
+++ b/JournalApp/Pages/SafetyPlanning/SafetyPlanPage.razor.css
@@ -2,7 +2,7 @@
 .safety-plan-items-container {
   display: flex;
   flex-direction: column;
-  gap: 3px;
+  gap: 4px;
 }
 
 ::deep .safety-plan-item {
@@ -10,18 +10,18 @@
   flex-direction: column;
   gap: 12px;
   background-color: var(--mud-palette-surface);
-  border-radius: 6px;
+  border-radius: var(--ja-shape-sm);
   padding: 14px 16px;
 }
 
 ::deep .safety-plan-item:first-child {
-  border-top-left-radius: 18px;
-  border-top-right-radius: 18px;
+  border-top-left-radius: var(--ja-shape-lg-increased);
+  border-top-right-radius: var(--ja-shape-lg-increased);
 }
 
 ::deep .safety-plan-item:last-child {
-  border-bottom-left-radius: 18px;
-  border-bottom-right-radius: 18px;
+  border-bottom-left-radius: var(--ja-shape-lg-increased);
+  border-bottom-right-radius: var(--ja-shape-lg-increased);
 }
 
 ::deep .safety-plan-item-header {

--- a/JournalApp/Pages/SettingsPage.razor.css
+++ b/JournalApp/Pages/SettingsPage.razor.css
@@ -8,7 +8,7 @@
 .settings-group {
   display: flex;
   flex-direction: column;
-  gap: 3px;
+  gap: 4px;
 }
 
 ::deep .settings-item {
@@ -16,18 +16,18 @@
   flex-direction: column;
   gap: 12px;
   background-color: var(--mud-palette-surface);
-  border-radius: 6px;
+  border-radius: var(--ja-shape-sm);
   padding: 14px 16px;
 }
 
 ::deep .settings-item:first-child {
-  border-top-left-radius: 18px;
-  border-top-right-radius: 18px;
+  border-top-left-radius: var(--ja-shape-lg-increased);
+  border-top-right-radius: var(--ja-shape-lg-increased);
 }
 
 ::deep .settings-item:last-child {
-  border-bottom-left-radius: 18px;
-  border-bottom-right-radius: 18px;
+  border-bottom-left-radius: var(--ja-shape-lg-increased);
+  border-bottom-right-radius: var(--ja-shape-lg-increased);
 }
 
 ::deep .settings-item-title {

--- a/JournalApp/Pages/Trends/TrendsPage.razor
+++ b/JournalApp/Pages/Trends/TrendsPage.razor
@@ -17,6 +17,25 @@
 </header>
 
 <main class="page-body">
+    @if (!_loaded)
+    {
+        <div class="trends-status">
+            <MudProgressCircular Color="Color.Primary" Indeterminate />
+        </div>
+    }
+    else if (AllPoints.Count == 0)
+    {
+        <div class="trends-status">
+            <MudIcon Class="trends-status-icon" Icon="@Icons.Material.Rounded.ShowChart" />
+
+            <MudText Typo="Typo.h6">Nothing to chart yet</MudText>
+
+            <MudText Class="trends-status-detail" Typo="Typo.body2" Align="Align.Center">
+                Anything you record on these days will show up here.
+            </MudText>
+        </div>
+    }
+
     <div id="trends-category-list">
         @foreach (var (category, points) in AllPoints.OrderBy(x => x.Key.Group).ThenBy(x => x.Key.Index))
         {
@@ -52,6 +71,8 @@
 
     Dictionary<DataPointCategory, IReadOnlyDictionary<DateOnly, IReadOnlyCollection<DataPoint>>> AllPoints = new();
 
+    bool _loaded;
+
     protected override void OnInitialized()
     {
         logger.LogDebug("Initializing");
@@ -67,6 +88,10 @@
     {
         logger.LogInformation("Loading trends for {StartDate}..{EndDate}", SelectedDates[0], SelectedDates[^1]);
         var sw = Stopwatch.StartNew();
+
+        // Charts take a moment to come back, and without this the page is blank in exactly the same way an empty month is.
+        _loaded = false;
+        StateHasChanged();
 
         await using var db = await DbFactory.CreateDbContextAsync();
 
@@ -96,6 +121,8 @@
 
             AllPoints.Add(group.Key, pointsByDate);
         }
+
+        _loaded = true;
 
         sw.Stop();
         logger.LogInformation("Loaded trends data in {ElapsedMilliseconds}ms (categories: {CategoryCount})", sw.ElapsedMilliseconds, AllPoints.Count);

--- a/JournalApp/Pages/Trends/TrendsPage.razor.css
+++ b/JournalApp/Pages/Trends/TrendsPage.razor.css
@@ -10,9 +10,10 @@
   flex-direction: column;
 }
 
+/* Each chart sits in a group container, so it takes the same large radius as a grouped list. */
 ::deep .trend-view {
   padding: 8px;
   gap: 16px;
   background-color: var(--mud-palette-surface);
-  border-radius: 16px;
+  border-radius: var(--ja-shape-lg-increased);
 }

--- a/JournalApp/Pages/Trends/TrendsPage.razor.css
+++ b/JournalApp/Pages/Trends/TrendsPage.razor.css
@@ -10,6 +10,26 @@
   flex-direction: column;
 }
 
+/* A month with no entries used to render nothing at all, which reads as a broken page rather than an empty one. */
+.trends-status {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  margin-top: 20vh;
+  color: var(--mud-palette-text-secondary);
+}
+
+::deep .trends-status-icon {
+  width: 48px;
+  height: 48px;
+  font-size: 48px;
+}
+
+::deep .trends-status-detail {
+  max-width: 32ch;
+}
+
 /* Each chart sits in a group container, so it takes the same large radius as a grouped list. */
 ::deep .trend-view {
   padding: 8px;

--- a/JournalApp/Pages/Worksheets/WorksheetsPage.razor.css
+++ b/JournalApp/Pages/Worksheets/WorksheetsPage.razor.css
@@ -19,14 +19,21 @@
   margin: 0;
 }
 
+/* The title is a MudLink whose inline box hugs its text, so a wrapped title used to sit lower in its card than a single-line one. */
+/* Blocking it out gives every card the same 14px above the first line of the title. */
 ::deep .worksheet-view {
   display: flex;
   flex-direction: column;
-  align-items: start;
+  align-items: stretch;
   gap: 4px;
   background-color: var(--mud-palette-surface);
   border-radius: var(--ja-shape-sm);
   padding: 14px 16px;
+}
+
+::deep .worksheet-view-title {
+  display: block;
+  line-height: 1.4;
 }
 
 ::deep .worksheet-view:first-child {

--- a/JournalApp/Pages/Worksheets/WorksheetsPage.razor.css
+++ b/JournalApp/Pages/Worksheets/WorksheetsPage.razor.css
@@ -13,7 +13,7 @@
 .worksheet-group-items {
   display: flex;
   flex-direction: column;
-  gap: 3px;
+  gap: 4px;
   list-style-type: none;
   padding: 0;
   margin: 0;
@@ -25,18 +25,18 @@
   align-items: start;
   gap: 4px;
   background-color: var(--mud-palette-surface);
-  border-radius: 6px;
+  border-radius: var(--ja-shape-sm);
   padding: 14px 16px;
 }
 
 ::deep .worksheet-view:first-child {
-  border-top-left-radius: 18px;
-  border-top-right-radius: 18px;
+  border-top-left-radius: var(--ja-shape-lg-increased);
+  border-top-right-radius: var(--ja-shape-lg-increased);
 }
 
 ::deep .worksheet-view:last-child {
-  border-bottom-left-radius: 18px;
-  border-bottom-right-radius: 18px;
+  border-bottom-left-radius: var(--ja-shape-lg-increased);
+  border-bottom-right-radius: var(--ja-shape-lg-increased);
 }
 
 ::deep .worksheet-view-title {
@@ -59,10 +59,11 @@
   margin: 0;
 }
 
+/* M3 assist chips: a medium-radius container with the outline role, the only neutral boundary that clears 3:1 on a light surface. */
 .worksheet-group-toc-item {
   white-space: nowrap;
-  border: 1px solid var(--mud-palette-lines-default);
-  border-radius: 8px;
+  border: 1px solid var(--mud-palette-lines-inputs);
+  border-radius: var(--ja-shape-md);
   padding: 6px 12px;
 }
 

--- a/JournalApp/Platforms/Android/MainActivity.cs
+++ b/JournalApp/Platforms/Android/MainActivity.cs
@@ -10,6 +10,11 @@ public class MainActivity : MauiAppCompatActivity
 {
     protected override void OnCreate(Bundle savedInstanceState)
     {
+        // The WebView's selection handles, magnifier and caret are native chrome tinted from the activity theme, and the theme is read once when the view is created.
+        // The theme's own accent is the stock Orchid, so it only needs an overlay while the palette is actually coming from the wallpaper instead.
+        if (Preferences.Default.Get("device_colors", true) && OperatingSystem.IsAndroidVersionAtLeast(31))
+            Theme.ApplyStyle(Resource.Style.JournalApp_DeviceAccent, force: true);
+
         base.OnCreate(savedInstanceState);
 
         // The web layer dodges the keyboard itself by watching the visual viewport, so keep the window static and let CSS animate the dodge.

--- a/JournalApp/Platforms/Android/Resources/values-night-v31/styles.xml
+++ b/JournalApp/Platforms/Android/Resources/values-night-v31/styles.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Tone 200 is the system step matching the dark scheme's tone 80 primary. -->
+    <style name="JournalApp.DeviceAccent" parent="">
+        <item name="colorAccent">@android:color/system_accent1_200</item>
+        <item name="colorSecondary">@android:color/system_accent1_200</item>
+        <item name="colorControlActivated">@android:color/system_accent1_200</item>
+    </style>
+</resources>

--- a/JournalApp/Platforms/Android/Resources/values-night/colors.xml
+++ b/JournalApp/Platforms/Android/Resources/values-night/colors.xml
@@ -2,4 +2,6 @@
 <resources>
     <!-- Matches the Orchid theme's dark background (neutral 6) so the splash flows straight into the Blazor loading screen. -->
     <color name="splash_background">#181215</color>
+    <!-- The dark palette lifts the primary to tone 80, and the selection handles have to follow or they read as ink on ink. -->
+    <color name="colorAccent">#F7B1DE</color>
 </resources>

--- a/JournalApp/Platforms/Android/Resources/values-v31/styles.xml
+++ b/JournalApp/Platforms/Android/Resources/values-v31/styles.xml
@@ -1,7 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- No windowSplashScreenAnimatedIcon: the system then shows the real launcher icon, plate and all, which is the standard Android 12+ splash look. -->
-    <style name="Maui.SplashTheme" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+    <style name="Maui.SplashTheme" parent="JournalApp.Theme">
         <item name="android:windowSplashScreenBackground">@color/splash_background</item>
+    </style>
+
+    <!-- Applied over the activity theme at startup only while the app is actually seeded from the wallpaper, so the native handles track the same palette the UI does. -->
+    <!-- Tone 600 is the system step closest to the primary the generator produces for a light scheme. -->
+    <style name="JournalApp.DeviceAccent" parent="">
+        <item name="colorAccent">@android:color/system_accent1_600</item>
+        <item name="colorSecondary">@android:color/system_accent1_600</item>
+        <item name="colorControlActivated">@android:color/system_accent1_600</item>
     </style>
 </resources>

--- a/JournalApp/Platforms/Android/Resources/values/colors.xml
+++ b/JournalApp/Platforms/Android/Resources/values/colors.xml
@@ -2,6 +2,8 @@
 <resources>
     <color name="colorPrimary">#844C72</color>
     <color name="colorPrimaryDark">#844C72</color>
+    <!-- The stock Orchid primary, used for the native selection handles below Android 12 and whenever there is no system palette to follow. -->
+    <color name="colorAccent">#844C72</color>
     <!-- Matches the Orchid theme's light background (neutral 98) so the splash flows straight into the Blazor loading screen. -->
     <color name="splash_background">#FFF8F9</color>
     <!-- The launcher icon's pink plate, drawn behind the pre-Android-12 splash glyph so it reads as the app icon; 12+ shows the real launcher icon instead. -->

--- a/JournalApp/Platforms/Android/Resources/values/styles.xml
+++ b/JournalApp/Platforms/Android/Resources/values/styles.xml
@@ -1,6 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="Maui.SplashTheme" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+    <!-- The selection handles, the magnifier and the caret inside the WebView are native chrome tinted from the activity theme, which CSS cannot reach. -->
+    <!-- Without these the platform falls back to the Material Components default secondary, a teal that belongs to no palette this app generates. -->
+    <style name="JournalApp.Theme" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <item name="colorAccent">@color/colorAccent</item>
+        <item name="colorSecondary">@color/colorAccent</item>
+        <item name="colorControlActivated">@color/colorAccent</item>
+    </style>
+
+    <style name="Maui.SplashTheme" parent="JournalApp.Theme">
         <item name="android:windowBackground">@drawable/splash_screen</item>
+    </style>
+
+    <!-- Below Android 12 there is no wallpaper palette to follow, so the device-accent overlay is the stock Orchid the app falls back to anyway. -->
+    <style name="JournalApp.DeviceAccent" parent="">
+        <item name="colorAccent">@color/colorAccent</item>
+        <item name="colorSecondary">@color/colorAccent</item>
+        <item name="colorControlActivated">@color/colorAccent</item>
     </style>
 </resources>

--- a/JournalApp/wwwroot/app.css
+++ b/JournalApp/wwwroot/app.css
@@ -1,4 +1,4 @@
-﻿* {
+* {
   -webkit-tap-highlight-color: transparent;
 }
 
@@ -6,11 +6,43 @@ body {
   user-select: none;
   --mud-palette-action-default: var(--mud-palette-text-primary);
   color-scheme: light dark;
+
+  /* The M3 shape scale, so every container picks its radius from one ladder instead of an ad-hoc number. */
+  --ja-shape-xs: 4px;
+  --ja-shape-sm: 8px;
+  --ja-shape-md: 12px;
+  --ja-shape-lg: 16px;
+  --ja-shape-lg-increased: 20px;
+  --ja-shape-xl: 28px;
+  --ja-shape-full: 999px;
+
+  /* M3 Expressive motion. Spatial springs are underdamped so size, position and shape overshoot slightly. */
+  --ja-motion-spatial: 300ms cubic-bezier(0.27, 1.06, 0.18, 1);
+  /* Effects springs are critically damped, so color and opacity must never overshoot. */
+  --ja-motion-effects: 200ms cubic-bezier(0.2, 0, 0, 1);
+
+  /* The two soft lifts the app uses: a container resting above the page, and the header once content passes under it. */
+  --ja-shadow-raised: 0 1px 2px rgba(0, 0, 0, 0.10), 0 2px 6px 1px rgba(0, 0, 0, 0.07);
+  --ja-shadow-scrolled: 0 6px 10px -6px rgba(0, 0, 0, 0.16), 0 10px 24px -10px rgba(0, 0, 0, 0.10);
+  /* M3 elevation level 3, which is what dialogs and menus sit at. */
+  --ja-shadow-level3: 0 1px 3px rgba(0, 0, 0, 0.30), 0 4px 8px 3px rgba(0, 0, 0, 0.15);
 }
 
   body::-webkit-scrollbar {
     display: none;
   }
+
+/* Text selection and the caret otherwise fall back to the platform accent, which is the stock blue rather than the app's primary. */
+::selection {
+  background-color: var(--mud-palette-primary-lighten);
+  color: var(--mud-palette-primary-darken);
+}
+
+input,
+textarea,
+[contenteditable] {
+  caret-color: var(--mud-palette-primary);
+}
 
 /* Background colors come from the theme-matched media queries at the bottom so the native splash, this loading screen, and the app all share one tone. */
 #splash-screen {
@@ -28,30 +60,36 @@ body {
   font-size: 6vw;
 }
 
-/* The sticky header ends flush at the pill so scrolling content passes under a clean edge instead of a same-color strip. */
+/* The day, month and year switcher is a full-corner container that rests above the page, like an M3 search bar. */
+/* It carries its own lift instead of relying on a full-width line under the header, which used to slice straight through the pill. */
 .switcher {
   display: flex;
   justify-content: center;
   align-items: center;
-  border-radius: 999px;
+  height: 48px;
+  border-radius: var(--ja-shape-full);
   margin: 0 8px;
-  background-color: var(--mud-palette-surface);
+  background-color: var(--mud-palette-gray-lighter);
+  box-shadow: var(--ja-shadow-raised);
 }
 
 .switcher-header {
   display: flex;
   justify-content: center;
-  width: 55vw;
+  flex: 1;
+  min-width: 0;
 }
 
 .page {
 }
 
+/* M3 small top app bar: 64dp tall, title-large title, trailing icons on the neutral action color. */
 .page-toolbar {
   display: flex;
   flex-direction: row;
   align-items: center;
   gap: 8px;
+  min-height: 64px;
   padding: 0;
   box-shadow: none;
   background-color: var(--mud-palette-background);
@@ -65,17 +103,24 @@ body {
   font-weight: 400;
 }
 
+/* The leading navigation icon is onSurface; only the trailing icons are onSurfaceVariant. */
+.page-toolbar > .mud-icon-button:first-child {
+  color: var(--mud-palette-text-primary);
+}
+
 /* Match the date button to title-large as well. */
 .switcher-header .mud-typography-h5 {
   font-size: 22px;
   font-weight: 400;
 }
 
+/* The toolbar and switcher rows together make up a 120dp two-row app bar, with 8dp under the pill so scrolling content never touches it. */
 .page-header {
   z-index: var(--mud-zindex-appbar);
   display: flex;
   flex-direction: column;
   padding: 0 !important;
+  padding-bottom: 8px !important;
   margin: 0 !important;
   top: 0 !important;
   position: sticky !important;
@@ -83,7 +128,7 @@ body {
   color: var(--mud-palette-text-primary);
 }
 
-/* On-scroll separation for the sticky header: a soft M3 level-1 shadow fades in once content passes underneath. */
+/* On-scroll separation for the sticky header: a soft lift fades in once content passes underneath. */
 /* MD3 proper would retone the container instead, but that desyncs the natively colored status bar, so elevation stands in until edge-to-edge lands. */
 @supports (animation-timeline: scroll()) {
   .page-header {
@@ -93,9 +138,11 @@ body {
   }
 }
 
+/* The lift carries an outlineVariant hairline as well, because a black shadow does nothing over a tone-6 dark surface. */
+/* The hairline has to come from the palette rather than a prefers-color-scheme branch: the WebView reports the OS theme, not the theme the user picked in the app. */
 @keyframes header-on-scroll {
   to {
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3), 0 1px 3px 1px rgba(0, 0, 0, 0.15);
+    box-shadow: 0 1px 0 var(--mud-palette-lines-default), var(--ja-shadow-scrolled);
   }
 }
 
@@ -105,7 +152,7 @@ body {
   margin: 0 auto !important;
   padding: 8px !important;
   padding-bottom: 15vh !important;
-  animation: fadeInUp 0.15s ease-out;
+  animation: fadeInUp var(--ja-motion-spatial);
 }
 
 @keyframes fadeInUp {
@@ -143,93 +190,156 @@ body {
 }
 
 /* M3E connected button group: tonal segments separated by 2px gaps instead of an outlined pill with dividers. */
-/* The row of segments keeps fully rounded outer corners, and the selected segment morphs to a full pill with a secondaryContainer fill. */
+/* The row of segments keeps fully rounded outer corners, and the selected segment morphs to a full pill. */
 .mud-toggle-group {
   flex-grow: 1;
   gap: 2px;
   border: none !important;
+  border-radius: var(--ja-shape-full);
   background-color: transparent;
 }
 
+/* MudBlazor pulls each segment 1px left to collapse outlined borders, which eats half of the 2dp M3E gap. */
 .mud-toggle-group .mud-toggle-item {
-  color: var(--mud-palette-text-primary);
-  background-color: var(--mud-palette-gray-lighter);
+  margin-left: 0 !important;
+}
+
+/* Tone alone cannot separate a control from its card in light mode, where neighbouring neutral surfaces are only 1.05:1 apart. */
+/* Chroma can: an unselected segment takes the tonal-button pair (secondaryContainer on onSecondaryContainer, 7.25:1), and the selected one is a filled primary pill (5.5:1 against the card). */
+.mud-toggle-group .mud-toggle-item {
+  color: var(--mud-palette-secondary-darken);
+  background-color: var(--mud-palette-secondary-lighten);
   border: none !important;
-  border-radius: 8px;
-  min-height: 32px;
-  transition: border-radius 0.15s ease-out, background-color 0.15s ease-out;
+  min-height: 48px;
+  font-size: 14px;
+  font-weight: 500;
+  border-radius: var(--ja-shape-sm);
+  transition: border-radius var(--ja-motion-spatial), background-color var(--ja-motion-effects), color var(--ja-motion-effects);
 }
 
 .mud-toggle-group .mud-toggle-item:first-child {
-  border-top-left-radius: 999px;
-  border-bottom-left-radius: 999px;
+  border-top-left-radius: var(--ja-shape-full);
+  border-bottom-left-radius: var(--ja-shape-full);
 }
 
 .mud-toggle-group .mud-toggle-item:last-child {
-  border-top-right-radius: 999px;
-  border-bottom-right-radius: 999px;
+  border-top-right-radius: var(--ja-shape-full);
+  border-bottom-right-radius: var(--ja-shape-full);
 }
 
 .mud-toggle-group .mud-toggle-item.mud-toggle-item-selected {
-  background-color: var(--mud-palette-secondary-lighten);
-  color: var(--mud-palette-secondary-darken);
-  border-radius: 999px;
+  background-color: var(--mud-palette-primary);
+  color: var(--mud-palette-primary-text);
+  border-radius: var(--ja-shape-full);
 }
 
+/* M3E small buttons are 40dp tall; MudBlazor's own padding leaves them at ~36px. */
 .mud-button {
-  border-radius: 999px;
+  border-radius: var(--ja-shape-full);
+  min-height: 40px;
 }
 
-/* M3 outlined buttons and button groups use the neutral outline-variant, not a text- or primary-tinted border. */
-.mud-button-outlined {
-  border-color: var(--mud-palette-lines-default);
+/* M3 outlined buttons and button groups draw their boundary in the outline role, which is the only neutral that clears 3:1 against a light surface. */
+/* The compound selectors are needed because MudBlazor's own per-color rules outrank a single class. */
+.mud-button-outlined,
+.mud-button-outlined.mud-button-outlined-primary,
+.mud-button-outlined.mud-button-outlined-default {
+  border-color: var(--mud-palette-lines-inputs);
 }
 
 .mud-button-group-outlined.mud-button-group-override-styles .mud-button-root {
-  border-color: var(--mud-palette-lines-default);
+  border-color: var(--mud-palette-lines-inputs);
 }
 
+/* M3E connected button group geometry, the same one the toggle groups use: 2dp gaps, small inner corners, full outer corners. */
+/* MudBlazor collapses the inner corners to 0 and overlaps the members by 1px, which reads as a table rather than a button group. */
 .mud-button-group-root {
-  border-radius: 999px;
+  border-radius: var(--ja-shape-full);
+  gap: 2px;
+}
+
+.mud-button-group-horizontal:not(.mud-button-group-rtl) > .mud-button-root:not(:last-child),
+.mud-button-group-horizontal:not(.mud-button-group-rtl) > :not(:last-child) .mud-button-root {
+  border-top-right-radius: var(--ja-shape-sm);
+  border-bottom-right-radius: var(--ja-shape-sm);
+}
+
+.mud-button-group-horizontal:not(.mud-button-group-rtl) > .mud-button-root:not(:first-child),
+.mud-button-group-horizontal:not(.mud-button-group-rtl) > :not(:first-child) .mud-button-root {
+  border-top-left-radius: var(--ja-shape-sm);
+  border-bottom-left-radius: var(--ja-shape-sm);
+  margin-left: 0;
+}
+
+.mud-button-group-root > .mud-button-root:first-child {
+  border-top-left-radius: var(--ja-shape-full);
+  border-bottom-left-radius: var(--ja-shape-full);
+}
+
+.mud-button-group-root > .mud-button-root:last-child {
+  border-top-right-radius: var(--ja-shape-full);
+  border-bottom-right-radius: var(--ja-shape-full);
 }
 
 .mud-button-filled.mud-button-filled-primary {
   color: var(--mud-palette-primary-text);
 }
 
-/* M3 expressive slider: thick rounded track, primary fill, and a narrow bar handle instead of a floating circle. */
+/* M3E slider: a 16dp rounded track, primary active fill, and a narrow bar handle instead of a floating circle. */
+/* MudBlazor paints the range input above the active bar, so the inactive track moves onto the container beneath it and the active bar gets its own layer. */
 /* Selectors include the size class because MudBlazor's size rules (e.g. .mud-slider-small) otherwise win the cascade. */
-.mud-slider .mud-slider-input::-webkit-slider-runnable-track,
-.mud-slider.mud-slider-small .mud-slider-input::-webkit-slider-runnable-track {
-  height: 12px;
-  margin: 5px 0;
-  border-radius: 999px;
+.mud-slider.mud-slider-primary .mud-slider-input::-webkit-slider-runnable-track,
+.mud-slider.mud-slider-small .mud-slider-input::-webkit-slider-runnable-track,
+.mud-slider.mud-slider-medium .mud-slider-input::-webkit-slider-runnable-track {
+  background-color: transparent;
+  background-image: none;
+  height: 16px;
+  margin: 3px 0;
 }
 
 /* The inactive track carries the M3E stop indicator dot near its trailing end. */
-.mud-slider.mud-slider-primary .mud-slider-input::-webkit-slider-runnable-track {
+.mud-slider .mud-slider-inner-container::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 50%;
+  height: 16px;
+  transform: translateY(-50%);
+  border-radius: var(--ja-shape-full);
   background-color: var(--mud-palette-secondary-lighten);
   background-image: radial-gradient(circle, var(--mud-palette-primary) 0 2px, transparent 2.5px);
   background-repeat: no-repeat;
-  background-position: right 5px center;
+  background-position: right 6px center;
   background-size: 5px 5px;
 }
 
 .mud-slider .mud-slider-filled,
-.mud-slider.mud-slider-small .mud-slider-filled {
-  height: 12px;
-  border-radius: 6px 2px 2px 6px;
+.mud-slider.mud-slider-small .mud-slider-filled,
+.mud-slider.mud-slider-medium .mud-slider-filled {
+  position: relative;
+  z-index: 1;
+  height: 16px;
+  border-radius: var(--ja-shape-full);
 }
 
 .mud-slider .mud-slider-input::-webkit-slider-thumb,
-.mud-slider.mud-slider-small .mud-slider-input::-webkit-slider-thumb {
+.mud-slider.mud-slider-small .mud-slider-input::-webkit-slider-thumb,
+.mud-slider.mud-slider-medium .mud-slider-input::-webkit-slider-thumb {
   width: 4px;
-  height: 24px;
+  height: 32px;
   transform: none;
-  border-radius: 2px;
-  margin-top: -6px;
+  border-radius: var(--ja-shape-full);
+  margin-top: -8px;
+  background-color: var(--mud-palette-primary);
   /* M3E carves a gap between the handle and the track; surface-colored blocks either side of the bar fake it over the row container. */
   box-shadow: 6px 0 0 var(--mud-palette-surface), -6px 0 0 var(--mud-palette-surface);
+}
+
+/* MudBlazor swaps in an M2 focus ring on press, which would drop the gap exactly while the handle is being dragged. */
+.mud-slider .mud-slider-input:active::-webkit-slider-thumb,
+.mud-slider .mud-slider-input:focus::-webkit-slider-thumb {
+  box-shadow: 6px 0 0 var(--mud-palette-surface), -6px 0 0 var(--mud-palette-surface) !important;
 }
 
 /* M3 switch: 52x32 pill track with an outline, solid colors instead of translucent overlays, and a thumb that grows when checked. */
@@ -241,7 +351,7 @@ body {
 }
 
 .mud-switch-span .mud-switch-track {
-  border-radius: 999px;
+  border-radius: var(--ja-shape-full);
   opacity: 1;
   background-color: var(--mud-palette-gray-light);
   border: 2px solid var(--mud-palette-lines-inputs);
@@ -294,16 +404,43 @@ label.mud-switch.mud-disabled .mud-switch-span {
 }
 
 /* M3 settings rows lead with the label and keep the switch on the trailing edge. Scoped to the label element because MudSwitch reuses the mud-switch class on its inner text span. */
+/* The label is the whole tap target, so it takes the 48dp minimum rather than the 32px height of the switch itself. */
 .settings-group label.mud-switch {
   width: 100%;
+  min-height: 48px;
   flex-direction: row-reverse;
   justify-content: space-between;
   margin-inline-start: 0;
 }
 
-/* M3 menus and popovers sit on surfaceContainerHigh. */
+/* MudBlazor's text alerts are a low-alpha wash that all but disappears on a light surface, so they take a real tonal container instead. */
+.mud-alert-text-info {
+  background-color: var(--mud-palette-info-lighten);
+}
+
+.mud-alert-text-warning {
+  background-color: var(--mud-palette-warning-lighten);
+}
+
+.mud-alert-text-error {
+  background-color: var(--mud-palette-error-lighten);
+}
+
+.mud-alert-text-success {
+  background-color: var(--mud-palette-success-lighten);
+}
+
+/* Menus and popovers take surfaceContainerHighest, one step above the dialog container, so a dropdown opened inside a dialog still separates from it. */
 .mud-popover {
-  --mud-palette-surface: var(--mud-palette-gray-lighter);
+  --mud-palette-surface: var(--mud-palette-gray-light);
+  border-radius: var(--ja-shape-lg);
+  max-width: calc(100vw - 16px);
+  box-shadow: var(--ja-shadow-level3);
+}
+
+.mud-popover.mud-popover-top-right,
+.mud-popover.mud-popover-bottom-right {
+  margin-right: 8px;
 }
 
 /* The keyboard overlays the WebView and shrinks the visual viewport; pinning the container to it glides dialogs out of the keyboard's way. */
@@ -322,12 +459,13 @@ body {
   padding-bottom: var(--keyboard-inset, 0px);
 }
 
-/* M3 dialogs sit on surfaceContainerHigh with the 24px container inset. */
+/* M3 dialogs sit on surfaceContainerHigh with the 24px container inset, at elevation Level3 rather than MudBlazor's M2 elevation 24. */
 .mud-dialog {
   padding: 24px !important;
   gap: 16px !important;
-  border-radius: 28px;
+  border-radius: var(--ja-shape-xl);
   --mud-palette-surface: var(--mud-palette-gray-lighter);
+  box-shadow: var(--ja-shadow-level3);
 }
 
 /* M3 dialog headline is headline-small on the leading edge, not a centered bold h6. */
@@ -336,6 +474,11 @@ body {
   display: flex;
   align-items: center;
   justify-content: flex-start;
+}
+
+/* Message boxes ship an empty title, which would otherwise leave a headline-sized gap above the message. */
+.mud-dialog-title:not(:has(*)) {
+  display: none;
 }
 
 .mud-dialog-title .mud-typography-h6 {
@@ -349,6 +492,13 @@ body {
   color: var(--mud-palette-text-secondary);
 }
 
+/* The rule above is for supporting text, so anything the user actually reads back or edits stays on onSurface. */
+.mud-dialog-content .mud-input-slot,
+.mud-dialog-content .mud-input-root,
+.mud-dialog-content .mud-select-input {
+  color: var(--mud-palette-text-primary);
+}
+
 .mud-dialog-actions {
   gap: 8px;
   justify-content: flex-end;
@@ -358,7 +508,7 @@ body {
 .mud-card {
   padding: 12px !important;
   gap: 12px !important;
-  border-radius: 16px;
+  border-radius: var(--ja-shape-md);
   box-shadow: none;
 }
 
@@ -389,28 +539,34 @@ body {
   display: none;
 }
 
-/* M3 snackbar: inverse surface. */
-.mud-snackbar {
+/* M3 snackbar: inverse surface. The compound selector is needed because MudBlazor's own .mud-snackbar-surface rule outranks a single class. */
+.mud-snackbar,
+.mud-snackbar.mud-snackbar-surface {
   background-color: var(--mud-palette-dark);
   color: var(--mud-palette-dark-text);
+  border-radius: var(--ja-shape-xs);
 }
 
+/* The mood button is a tonal container like the other controls, so it stays visible on a light card. */
 .emoji-button {
   padding: 0;
   min-width: 48px;
   height: 48px;
   border-radius: 50%;
-  background-color: var(--mud-palette-gray-lighter);
+  background-color: var(--mud-palette-secondary-lighten);
 }
 
 .emoji-popover-content {
   display: flex;
   flex-direction: column;
-  border-radius: 12px;
+  border-radius: var(--ja-shape-lg);
   box-shadow: var(--mud-elevation-8);
 }
 
-.list-group-title {
+/* M3 list section headers are title-small on onSurfaceVariant. The link variants inherit onSurface, so they need naming here too. */
+.list-group-title,
+.list-group-title.mud-link,
+a.list-group-title {
   font-size: var(--mud-typography-subtitle2-size);
   font-family: var(--mud-typography-subtitle2-family);
   font-weight: var(--mud-typography-subtitle2-weight);
@@ -428,38 +584,38 @@ body {
 .main-timeline .mud-card.data-point-group {
   background-color: transparent;
   padding: 0 !important;
-  gap: 3px !important;
+  gap: 4px !important;
 }
 
 .main-timeline .data-point-group .data-point-list {
-  gap: 3px;
+  gap: 4px;
 }
 
 .main-timeline .data-point-container {
   background-color: var(--mud-palette-surface);
-  border-radius: 6px;
+  border-radius: var(--ja-shape-sm);
   padding: 14px 16px;
 }
 
 .main-timeline .data-point-container:first-child {
-  border-top-left-radius: 18px;
-  border-top-right-radius: 18px;
+  border-top-left-radius: var(--ja-shape-lg-increased);
+  border-top-right-radius: var(--ja-shape-lg-increased);
 }
 
 .main-timeline .data-point-container:last-child {
-  border-bottom-left-radius: 18px;
-  border-bottom-right-radius: 18px;
+  border-bottom-left-radius: var(--ja-shape-lg-increased);
+  border-bottom-right-radius: var(--ja-shape-lg-increased);
 }
 
 /* When the group ends with an action row (New note), that row becomes the closing container instead of the last list item. */
 .main-timeline .data-point-group:has(.mud-card-actions .mud-button) .data-point-container:last-child {
-  border-bottom-left-radius: 6px;
-  border-bottom-right-radius: 6px;
+  border-bottom-left-radius: var(--ja-shape-sm);
+  border-bottom-right-radius: var(--ja-shape-sm);
 }
 
 .main-timeline .mud-card-actions:has(.mud-button) {
   background-color: var(--mud-palette-surface);
-  border-radius: 6px 6px 18px 18px;
+  border-radius: var(--ja-shape-sm) var(--ja-shape-sm) var(--ja-shape-lg-increased) var(--ja-shape-lg-increased);
   padding: 12px 16px !important;
 }
 
@@ -468,6 +624,62 @@ body {
   font-size: 16px;
   font-weight: 500;
   letter-spacing: 0.15px;
+}
+
+/* M3 filled text field, so number and text rows read as editable instead of as plain labels. */
+/* Without a container these fields are borderless transparent text and an empty one is invisible. */
+.main-timeline .data-point-container-number .mud-input,
+.main-timeline .data-point-container-text .mud-input {
+  background-color: var(--mud-palette-gray-light);
+  border-radius: var(--ja-shape-xs) var(--ja-shape-xs) 0 0;
+  border-bottom: 1px solid var(--mud-palette-lines-inputs);
+  padding: 4px 12px;
+  min-height: 40px;
+}
+
+/* A number never needs the whole row, and a full-width box for three digits reads as a form rather than a journal entry. */
+.main-timeline .data-point-container-number .mud-input {
+  max-width: 200px;
+}
+
+/* M3 filled fields thicken the active indicator to 2dp in primary while focused. */
+.main-timeline .data-point-container-number .mud-input:focus-within,
+.main-timeline .data-point-container-text .mud-input:focus-within {
+  border-bottom: 2px solid var(--mud-palette-primary);
+  padding-bottom: 3px;
+}
+
+/* The sleep stepper and the note edit pencil render at MudBlazor's small size, which is well under the 48dp target. */
+.sleep-controls .mud-icon-button,
+.note-container .note-edit-button {
+  min-width: 48px;
+  min-height: 48px;
+}
+
+/* ApexCharts bakes its own greys into the SVG it draws, so the axis ink, gridlines and tooltip are re-pointed at the palette here. */
+/* These rules can't live in the scoped stylesheet because the chart's SVG is created outside Blazor and carries no scope attribute. */
+.apexcharts-xaxis-label,
+.apexcharts-yaxis-label {
+  fill: var(--mud-palette-text-secondary);
+}
+
+.apexcharts-gridline,
+.apexcharts-xaxis line,
+.apexcharts-xaxis-tick {
+  stroke: var(--mud-palette-lines-default);
+}
+
+.apexcharts-tooltip {
+  background-color: var(--mud-palette-dark) !important;
+  color: var(--mud-palette-dark-text) !important;
+  border: none !important;
+  border-radius: var(--ja-shape-xs) !important;
+  box-shadow: var(--ja-shadow-level3) !important;
+}
+
+.apexcharts-tooltip-title {
+  background-color: var(--mud-palette-dark) !important;
+  border-bottom-color: var(--mud-palette-lines-default) !important;
 }
 
 #blazor-error-ui {
@@ -497,6 +709,29 @@ body {
 
   .flex-column, .navbar-brand {
     padding-left: env(safe-area-inset-left);
+  }
+}
+
+/* Android honors Remove animations under accessibility settings, so drop every entrance, transition and transform the app adds. */
+/* The scroll-driven header lift stays: it is tied to scroll position rather than to time, and it is the only cue that content is passing underneath. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
+
+  .page-body {
+    animation: none;
+  }
+
+  .mud-overlay .mud-overlay-scrim {
+    animation: none;
+  }
+
+  .calendar-day-cell:active {
+    transform: none;
   }
 }
 

--- a/JournalApp/wwwroot/app.css
+++ b/JournalApp/wwwroot/app.css
@@ -91,7 +91,6 @@ textarea,
   flex-direction: row;
   align-items: center;
   gap: 8px;
-  min-height: 64px;
   /* Android insets the leading glyph 16dp; an icon button already carries 12dp of its own, so the row adds the last 4dp. */
   padding: 0 4px;
   box-shadow: none;
@@ -117,18 +116,22 @@ textarea,
   font-weight: 400;
 }
 
-/* The toolbar and switcher rows together make up a 120dp two-row app bar, with 8dp under the pill so scrolling content never touches it. */
 .page-header {
   z-index: var(--mud-zindex-appbar);
   display: flex;
   flex-direction: column;
   padding: 0 !important;
-  padding-bottom: 8px !important;
   margin: 0 !important;
   top: 0 !important;
   position: sticky !important;
   background-color: var(--mud-palette-background);
   color: var(--mud-palette-text-primary);
+}
+
+/* Only a header carrying the switcher needs room under it, so scrolling content passes below the pill instead of through it. */
+/* Pages without one stay as tight as they were. */
+.page-header:has(.switcher) {
+  padding-bottom: 8px !important;
 }
 
 /* On-scroll separation for the sticky header: a soft lift fades in once content passes underneath. */
@@ -248,10 +251,8 @@ textarea,
   background-image: linear-gradient(rgba(var(--mud-palette-text-primary-rgb), 0.10), rgba(var(--mud-palette-text-primary-rgb), 0.10));
 }
 
-/* M3E small buttons are 40dp tall; MudBlazor's own padding leaves them at ~36px. */
 .mud-button {
   border-radius: var(--ja-shape-full);
-  min-height: 40px;
 }
 
 /* M3 outlined buttons and button groups draw their boundary in the outline role, which is the only neutral that clears 3:1 against a light surface. */
@@ -423,25 +424,12 @@ label.mud-switch.mud-disabled .mud-switch-span {
   opacity: 0.38;
 }
 
-/* The label is the whole tap target, so it takes the 48dp minimum rather than the 32px height of the switch track itself. */
-label.mud-switch {
-  min-height: 48px;
-}
-
 /* M3 settings rows lead with the label and keep the switch on the trailing edge. Scoped to the label element because MudSwitch reuses the mud-switch class on its inner text span. */
 .settings-group label.mud-switch {
   width: 100%;
   flex-direction: row-reverse;
   justify-content: space-between;
   margin-inline-start: 0;
-}
-
-/* A link that acts as a whole row needs a row-sized target; MudLink is otherwise only as tall as its text. */
-.settings-item .mud-link,
-.worksheet-view .mud-link {
-  display: flex;
-  align-items: center;
-  min-height: 48px;
 }
 
 /* MudBlazor's text alerts are a low-alpha wash that all but disappears on a light surface, so they take a real tonal container instead. */
@@ -580,13 +568,12 @@ body {
   border-radius: var(--ja-shape-xs);
 }
 
-/* The mood button is a tonal container like the other controls, so it stays visible on a light card. */
 .emoji-button {
   padding: 0;
   min-width: 48px;
   height: 48px;
   border-radius: 50%;
-  background-color: var(--mud-palette-secondary-lighten);
+  background-color: var(--mud-palette-gray-lighter);
 }
 
 .emoji-popover-content {
@@ -659,34 +646,21 @@ a.list-group-title {
   letter-spacing: 0.15px;
 }
 
-/* M3 filled text field, so number and text rows read as editable instead of as plain labels. */
-/* Without a container these fields are borderless transparent text and an empty one is invisible. */
+/* Number and text rows are borderless transparent text, so an unedited one is invisible. */
+/* An active indicator alone says the value is editable, without a filled box turning a journal row into a form field. */
 .main-timeline .data-point-container-number .mud-input,
 .main-timeline .data-point-container-text .mud-input {
-  background-color: var(--mud-palette-gray-light);
-  border-radius: var(--ja-shape-xs) var(--ja-shape-xs) 0 0;
   border-bottom: 1px solid var(--mud-palette-lines-inputs);
-  padding: 4px 12px;
-  min-height: 40px;
 }
 
-/* A number never needs the whole row, and a full-width box for three digits reads as a form rather than a journal entry. */
+/* A number never needs the whole row, and an indicator far wider than the value it sits under reads as a stray rule. */
 .main-timeline .data-point-container-number .mud-input {
-  max-width: 200px;
+  max-width: 120px;
 }
 
-/* M3 filled fields thicken the active indicator to 2dp in primary while focused. */
 .main-timeline .data-point-container-number .mud-input:focus-within,
 .main-timeline .data-point-container-text .mud-input:focus-within {
-  border-bottom: 2px solid var(--mud-palette-primary);
-  padding-bottom: 3px;
-}
-
-/* The sleep stepper and the note edit pencil render at MudBlazor's small size, which is well under the 48dp target. */
-.sleep-controls .mud-icon-button,
-.note-container .note-edit-button {
-  min-width: 48px;
-  min-height: 48px;
+  border-bottom-color: var(--mud-palette-primary);
 }
 
 /* ApexCharts bakes its own greys into the SVG it draws, so the axis ink, gridlines and tooltip are re-pointed at the palette here. */

--- a/JournalApp/wwwroot/app.css
+++ b/JournalApp/wwwroot/app.css
@@ -213,7 +213,8 @@ textarea,
   color: var(--mud-palette-secondary-darken);
   background-color: var(--mud-palette-secondary-lighten);
   border: none !important;
-  min-height: 48px;
+  /* The M3E extra-small connected group height. The timeline stacks a lot of these, so the taller sizes cost too much of the screen. */
+  min-height: 32px;
   font-size: 14px;
   font-weight: 500;
   border-radius: var(--ja-shape-sm);

--- a/JournalApp/wwwroot/app.css
+++ b/JournalApp/wwwroot/app.css
@@ -237,6 +237,17 @@ textarea,
   border-radius: var(--ja-shape-full);
 }
 
+/* MudBlazor renders an unselected segment as an outlined button, whose own :active rule swaps the container to primary-hover, so the tonal fill vanished exactly while a finger was on it. */
+/* M3 press feedback is a state layer composited over the resting fill, never a container swap, so both states keep their fill and take a 10% onSurface layer. */
+.mud-toggle-group .mud-toggle-item:not(.mud-toggle-item-selected):active,
+.mud-toggle-group .mud-toggle-item:not(.mud-toggle-item-selected):focus-visible {
+  background-color: var(--mud-palette-secondary-lighten);
+}
+
+.mud-toggle-group .mud-toggle-item:active {
+  background-image: linear-gradient(rgba(var(--mud-palette-text-primary-rgb), 0.10), rgba(var(--mud-palette-text-primary-rgb), 0.10));
+}
+
 /* M3E small buttons are 40dp tall; MudBlazor's own padding leaves them at ~36px. */
 .mud-button {
   border-radius: var(--ja-shape-full);
@@ -336,14 +347,19 @@ textarea,
   border-radius: var(--ja-shape-full);
   margin-top: -8px;
   background-color: var(--mud-palette-primary);
-  /* M3E carves a gap between the handle and the track; surface-colored blocks either side of the bar fake it over the row container. */
-  box-shadow: 6px 0 0 var(--mud-palette-surface), -6px 0 0 var(--mud-palette-surface);
+  /* M3E carves a 6dp gap either side of the handle; a surface-colored spread ring cuts it out of both tracks at once. */
+  box-shadow: 0 0 0 6px var(--mud-palette-surface);
 }
 
 /* MudBlazor swaps in an M2 focus ring on press, which would drop the gap exactly while the handle is being dragged. */
 .mud-slider .mud-slider-input:active::-webkit-slider-thumb,
 .mud-slider .mud-slider-input:focus::-webkit-slider-thumb {
-  box-shadow: 6px 0 0 var(--mud-palette-surface), -6px 0 0 var(--mud-palette-surface) !important;
+  box-shadow: 0 0 0 6px var(--mud-palette-surface) !important;
+}
+
+/* The active bar needs its own layer to clear the inactive track, which puts it above the range input too, so the input is lifted higher again or the handle and its gap are painted over. */
+.mud-slider .mud-slider-input {
+  z-index: 2;
 }
 
 /* M3 switch: 52x32 pill track with an outline, solid colors instead of translucent overlays, and a thumb that grows when checked. */

--- a/JournalApp/wwwroot/app.css
+++ b/JournalApp/wwwroot/app.css
@@ -66,11 +66,13 @@ textarea,
   display: flex;
   justify-content: center;
   align-items: center;
-  height: 48px;
+  min-height: 48px;
   border-radius: var(--ja-shape-full);
   margin: 0 8px;
   background-color: var(--mud-palette-gray-lighter);
   box-shadow: var(--ja-shadow-raised);
+  /* The steppers are supporting icons next to the date, so they read on onSurfaceVariant like every other trailing icon. */
+  --mud-palette-action-default: var(--mud-palette-text-secondary);
 }
 
 .switcher-header {
@@ -90,7 +92,8 @@ textarea,
   align-items: center;
   gap: 8px;
   min-height: 64px;
-  padding: 0;
+  /* Android insets the leading glyph 16dp; an icon button already carries 12dp of its own, so the row adds the last 4dp. */
+  padding: 0 4px;
   box-shadow: none;
   background-color: var(--mud-palette-background);
   color: var(--mud-palette-text-primary);
@@ -403,14 +406,25 @@ label.mud-switch.mud-disabled .mud-switch-span {
   opacity: 0.38;
 }
 
+/* The label is the whole tap target, so it takes the 48dp minimum rather than the 32px height of the switch track itself. */
+label.mud-switch {
+  min-height: 48px;
+}
+
 /* M3 settings rows lead with the label and keep the switch on the trailing edge. Scoped to the label element because MudSwitch reuses the mud-switch class on its inner text span. */
-/* The label is the whole tap target, so it takes the 48dp minimum rather than the 32px height of the switch itself. */
 .settings-group label.mud-switch {
   width: 100%;
-  min-height: 48px;
   flex-direction: row-reverse;
   justify-content: space-between;
   margin-inline-start: 0;
+}
+
+/* A link that acts as a whole row needs a row-sized target; MudLink is otherwise only as tall as its text. */
+.settings-item .mud-link,
+.worksheet-view .mud-link {
+  display: flex;
+  align-items: center;
+  min-height: 48px;
 }
 
 /* MudBlazor's text alerts are a low-alpha wash that all but disappears on a light surface, so they take a real tonal container instead. */
@@ -492,10 +506,12 @@ body {
   color: var(--mud-palette-text-secondary);
 }
 
-/* The rule above is for supporting text, so anything the user actually reads back or edits stays on onSurface. */
+/* The rule above is for supporting text, so anything the user actually reads back, edits or operates stays on onSurface. */
 .mud-dialog-content .mud-input-slot,
 .mud-dialog-content .mud-input-root,
-.mud-dialog-content .mud-select-input {
+.mud-dialog-content .mud-select-input,
+.mud-dialog-content label.mud-switch,
+.mud-dialog-content .mud-expand-panel-text {
   color: var(--mud-palette-text-primary);
 }
 

--- a/JournalApp/wwwroot/index.html
+++ b/JournalApp/wwwroot/index.html
@@ -7,7 +7,6 @@
         content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
     <title>Journal App</title>
     <base href="/" />
-    <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" rel="stylesheet" />
     <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
     <link href="app.css" rel="stylesheet" />
     <link href="JournalApp.styles.css" rel="stylesheet" />


### PR DESCRIPTION
Light mode had drifted well behind dark after #97, #103 and #111. Toggle buttons were the worst of it, and the sticky day switcher looked broken once you scrolled. This is a full pass over every surface rather than a patch on those two, and it introduces a small token system so the next component lands consistently instead of by hand.

## Why light mode broke, with numbers

The palette is not at fault, and neither is anyone's taste. It is arithmetic:

| adjacent container step | light | dark |
| --- | --- | --- |
| WCAG contrast | **1.05:1** | 1.13:1 |
| CIELAB dE76 | **1.95** | 4.81 |

Light mode's tonal step is about 2.5x weaker than dark's, and dE76 1.95 is at or below the just-noticeable-difference threshold. Every neutral-on-neutral pair in light mode is invisible, and no amount of tuning changes that:

| light pair | ratio |
| --- | --- |
| surfaceContainerLow vs surface | 1.06:1 |
| surfaceContainer vs surface | 1.11:1 |
| surfaceContainerHigh vs surface | 1.17:1 |
| surfaceContainerHighest vs surface | 1.23:1 |
| **unselected segment vs its card** | **1.05:1** |
| **selected segment vs unselected** | **1.05:1** |

I checked whether the surface ladder itself should move, and the spec says no. In the current Material Color Utilities [`color_spec_2025.ts`](https://github.com/material-foundation/material-color-utilities), the light surface container tones are **fixed constants with no ContrastCurve**, unlike the 2021 spec where they moved with contrast level. m3.material.io states it directly: "high contrast is applied to the content in a card but not the card container." The flat light ramp is intentional and permanent. That also matches what happened here previously, where two custom surface ramps were built, deployed and rejected on device.

So tone cannot carry control visibility in light mode. **Chroma can** — the neutral palette is chroma 6, secondaryContainer is chroma 16, primaryContainer 36 — and HCT lets chroma change without touching tone, so it costs nothing in contrast terms.

## The three conventions this PR introduces

**1. Container fill.** A control that sits on a tonal card never uses a neutral surface slot. Unselected takes the M3 tonal-button pair (`secondaryContainer` / `onSecondaryContainer`), and the active state is a filled `primary` pill (`primary` / `onPrimary`). That is the M3 filled-toggle-button selected role, and the docs explicitly permit substituting roles "as long as the container and text have a 3:1 contrast ratio".

| toggle group, light | before | after |
| --- | --- | --- |
| selected vs unselected | 1.05:1 | **5.00:1** |
| selected vs card | 1.05:1 | **5.53:1** |
| unselected label on its fill | 14.69:1 | 7.25:1 |
| selected label on its fill | 7.25:1 | **6.45:1** |

Dark mode gets the same treatment and stays strong (selected vs unselected 4.4:1).

**2. Shape.** A single M3 shape scale lives in `app.css` as custom properties and is used from the scoped `.razor.css` files too, since the vars cascade:

```
--ja-shape-xs 4  --ja-shape-sm 8  --ja-shape-md 12
--ja-shape-lg 16  --ja-shape-lg-increased 20  --ja-shape-xl 28  --ja-shape-full 999
```

Group containers and chart cards take `lg-increased`, rows inside a group `sm`, dialogs `xl`, buttons and segments `full`, snackbars and filled-field tops `xs`. Grouped lists moved off their ad-hoc 3/6/18px onto 4/8/20px. `DefaultBorderRadius` moved from 8px, which matches no M3E component, to the medium corner so anything not styled by hand still lands on a real token.

**3. Motion.** Two tokens rather than one, because M3E's motion system distinguishes them: `--ja-motion-spatial` overshoots slightly (M3E spatial springs are underdamped at 0.8 damping) and drives size, position and shape; `--ja-motion-effects` does not overshoot (effects springs are critically damped at 1.0) and drives colour and opacity. A `prefers-reduced-motion` branch now honours Android's "Remove animations" setting.

**4. Boundaries.** Everything that needs to read as an edge moved from `outlineVariant` (1.46:1 on a light card, which M3 designates decorative) to `outline` (3.86:1), which is the role for "important boundaries" and the only neutral that clears the 3:1 non-text floor in light mode.

**5. Density is a constraint, not a leftover.** The first pass of this PR raised the app bar to the 64dp M3 height and pushed buttons, switch rows, links, the sleep stepper and calendar day numbers up to their 48dp accessibility minimums. On device that was clearly wrong: reading a day's entries is the whole point of the screen, and the chrome was eating it. All of that is reverted. Where a spec minimum and legibility of the actual content disagree here, the content wins, and the contrast work is what carries usability instead of size. The one place size did increase is the slider, whose 16dp track and bar handle replace a 4px rail that was never visible.

## The scrolled header

The old sticky header ended flush at the bottom of the day pill, so the on-scroll shadow drew a hard `#A8A3A4` hairline straight through the pill's rounded corners and content butted directly against it. Sampled pixel by pixel down the edge, the shadow went from `#A8A3A4` to background in about 6px, which reads as a rendering artefact rather than elevation.

Now the pill is its own raised container (`surfaceContainerHigh`, full corners, its own soft lift, the M3 search-bar treatment), the header holds 8dp underneath it so scrolling content never touches it, and the scroll cue is a soft lift **plus** an `outlineVariant` hairline. The hairline is not cosmetic: a black shadow is invisible over a tone-6 dark surface, so without it dark mode had no scroll separation at all.

The 8dp only applies to headers that actually carry a switcher; Settings, Worksheets and Safety Plan stay as tight as they were. The leading nav icon is `onSurface` and the trailing and stepper icons are `onSurfaceVariant`, per spec.

I did not retone the bar to `surfaceContainer` on scroll, which is what M3 actually prescribes. On this app that desyncs the natively coloured status strip, and it was scrapped once before for exactly that reason. Elevation stands in until edge-to-edge lands.

## Defects the audit turned up

Several of these were invisible until measured or inspected in the live WebView over CDP:

- **The slider's active track never rendered at all.** MudBlazor emits `.mud-slider-inner-container` *before* the range input, so the input paints over `.mud-slider-filled`; making the inactive track opaque hid the fill completely. Fixed with a real three-layer stack: transparent runnable track, inactive track on the container's `::before`, active bar on its own layer, input lifted above both so the handle and its 6dp gaps survive.
- **Number and Text rows had no container**, so an unedited Weight field was literally invisible. They now carry a single active indicator, sized to the value rather than the row, which turns primary on focus.
- **`MudRating` painted `FullIcon` and `EmptyIcon` in the same colour**, and both were `Circle`, so Scale rows showed no value whatsoever. The empty icon is now hollow.
- **Pressing an unselected segment swapped its container to primary-hover**, so the tonal fill vanished under your finger. Press is now a state layer over the resting fill.
- **`MudButtonGroup` collapsed inner corners to 0 and overlapped members by 1px**, so Export/Import read as a table. It now uses the same connected-group geometry as the toggles.
- **Message boxes rendered an empty title row**, costing a headline of dead space above every confirmation.
- **Charts baked ApexCharts' own greys** into the SVG: axis ink, the x-axis baseline, tick marks and the tooltip all ignored the palette. Re-pointed at palette roles from global CSS, since the chart SVG is created outside Blazor and carries no scope attribute.
- **Trends rendered a completely blank page** for a month with no entries, and while loading. Both now have states.
- **The scrim was MudBlazor's hardcoded `rgba(33,33,33,0.5)`**, which lightens the page in dark mode. Now the M3 scrim, black at 32%, set on the palette slot rather than patched in CSS.
- **Worksheet cards were ragged.** The title is an inline `MudLink` whose box hugs its text, so a card with a wrapped title had visibly more space above it than one with a single-line title. Blocking the title out gives every card the same 14px above its first line.

## Native chrome

The teardrop handle and magnifier that appear when you focus a field are native chrome drawn by the WebView, not anything CSS can reach, and they take their colour from `colorControlActivated` on the activity theme. The theme parented straight onto `Theme.MaterialComponents` and never set it, so they came out `#03DAC6`, the Material Components default secondary: a teal belonging to no palette this app generates. The theme now carries the Orchid primary per mode, and `MainActivity` applies a wallpaper-accent overlay over it while the user has device colours on, so the handles follow whichever palette the UI is actually using. Verified both ways on the emulator: `#844C72` with device colours off, and an exact match to the generated primary with them on. The overlay is applied in `OnCreate` because the platform resolves handle drawables once, when the view is created, so toggling device colours only reaches the handles on the next launch.

`::selection` and `caret-color` are also pointed at the palette, which covers the parts of the selection UI that *are* web-layer.

At targetSdk 35+ `setStatusBarColor` is a no-op, so what actually tints the status bar is the MAUI page background showing through the transparent bar. That background was hardcoded to the Orchid seed, which meant Material You never reached the letterbox. `PreferenceService.ApplyPlatformTheme` now drives it from the generated palette, sets `UserAppTheme` so the native layer follows the in-app choice, and keeps `StatusBar.SetColor` for devices below Android 15 where it still does something.

While wiring that up I found `Application_RequestedThemeChanged` was overwriting the user's explicit theme with the OS theme, so picking Light or Dark silently reverted to whatever the system was doing. Fixed, with tests.

## Tests

239 passing, up from 236. `MaterialThemeTests.ToggleSegmentPairsStayLegibleForAnySeed` sweeps six seeds including black and white and asserts all four toggle pairs hold, so a Material You wallpaper cannot quietly break the contrast fix. `SecondaryLighten` and `SecondaryDarken` are now pinned, since the CSS depends on them.

## Verification

Everything was checked on a real Android emulator in both themes, at every step, including pixel sampling of the rendered output and computed-style inspection over the DevTools protocol. Not from mockups. One of my own changes was caught that way: I had branched the dark-mode header hairline on `prefers-color-scheme`, then measured that **the WebView reports the OS theme, not the app's theme**, so an in-app override would have fired the wrong branch. It now derives from the palette instead.

## Screenshots

Home, light

<!-- IMAGE: home-light before/after -->

Home scrolled, light — the header complaint

<!-- IMAGE: home-light-scrolled before/after -->

Home scrolled, dark

<!-- IMAGE: home-dark-scrolled before/after -->

Settings, light

<!-- IMAGE: settings-light before/after -->

Calendar, light

<!-- IMAGE: calendar-light before/after -->

Trends, light

<!-- IMAGE: trends-light before/after -->

Overflow menu, light

<!-- IMAGE: menu-light before/after -->

## Deliberately not done

- **The M3E tinted-neutral ramp.** The 2025 spec applies a chromaMultiplier (1.4/1.5/1.7) to the light surface containers, which is genuinely current spec, but it pushes every surface pinker, which is the direction that was rejected on device twice before. Happy to try it behind a flag if you want to see it.
- **The full M3 type scale.** #109 was closed, so typography stays as it is apart from putting the platform font first and dropping the Google Fonts request, which was a network fetch for a font Android already has.
- **A 3:1 boundary on unselected segments and on the slider's inactive track.** M3's clustered-container rule technically asks for one, and the fills are 1.11:1 against the card. I built it, looked at it on device, and it read busy: four outlined chips per row instead of one control. The filled selection carries the group instead. One line brings it back if you disagree: `.mud-toggle-group .mud-toggle-item:not(.mud-toggle-item-selected) { box-shadow: inset 0 0 0 1px var(--mud-palette-lines-inputs); }`
- **Scroll-under app bar retinting, a bottom nav bar, a FAB, press-squish on rows.** All previously scrapped.

## Known issues, unchanged by this PR

- Several elements remain below the 48dp touch minimum: the sleep stepper, the note edit pencil, rating dots, "Edit dose", and calendar day cells. That is a deliberate trade against density on a screen this dense, not an oversight.
- Dark-mode calendar day numbers sit at 3.46:1 on the deepest mood fills, short of 4.5:1. The two fixes available are a larger number or a darker mood ramp, and both were rejected: the number looked wrong at 20px, and the Coral Reef ramp was signed off separately.
- The navigation bar is correct on cold start and still stale after a runtime theme switch (#110). `UserAppTheme` does not fix it.
- Group labels are `<p>`, so TalkBack cannot navigate sections by heading. Calendar day cells have no accessible role or name.
- Disabled categories still cannot be edited or deleted, and their names render at 1.87:1.
- ApexCharts still draws fractional y-axis ticks on discrete metrics.
